### PR TITLE
MapperFactoryBean should return runtime type of mapper, if possible.

### DIFF
--- a/src/main/java/org/mybatis/spring/mapper/MapperFactoryBean.java
+++ b/src/main/java/org/mybatis/spring/mapper/MapperFactoryBean.java
@@ -48,14 +48,14 @@ import org.springframework.beans.factory.FactoryBean;
  * Note that this factory can only inject <em>interfaces</em>, not concrete classes.
  *
  * @author Eduardo Macarron
- * 
+ *
  * @see SqlSessionTemplate
  * @version $Id$
  */
 public class MapperFactoryBean<T> extends SqlSessionDaoSupport implements FactoryBean<T> {
 
+  private T mapperInstance;
   private Class<T> mapperInterface;
-
   private boolean addToConfig = true;
 
   /**
@@ -108,14 +108,19 @@ public class MapperFactoryBean<T> extends SqlSessionDaoSupport implements Factor
    * {@inheritDoc}
    */
   public T getObject() throws Exception {
-    return getSqlSession().getMapper(this.mapperInterface);
+    if (this.mapperInstance == null) {
+      this.mapperInstance = getSqlSession().getMapper(this.mapperInterface);
+    }
+    return this.mapperInstance;
   }
 
   /**
    * {@inheritDoc}
    */
-  public Class<T> getObjectType() {
-    return this.mapperInterface;
+  public Class<? extends T> getObjectType() {
+    return this.mapperInstance != null
+            ? this.mapperInstance.getClass().asSubclass(this.mapperInterface)
+            : this.mapperInterface;
   }
 
   /**

--- a/src/test/java/org/mybatis/spring/submitted/mappertype/IFooMapper.java
+++ b/src/test/java/org/mybatis/spring/submitted/mappertype/IFooMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mybatis.spring.submitted.mappertype;
+
+import org.apache.ibatis.annotations.Select;
+
+public interface IFooMapper {
+
+  @Select("select * from foo")
+  int selectInt();
+}

--- a/src/test/java/org/mybatis/spring/submitted/mappertype/MapperTypeTest.java
+++ b/src/test/java/org/mybatis/spring/submitted/mappertype/MapperTypeTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mybatis.spring.submitted.mappertype;
+
+import java.lang.reflect.Proxy;
+import java.util.Collection;
+import static org.hamcrest.CoreMatchers.*;
+import org.hamcrest.Matcher;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class MapperTypeTest {
+
+  @Test
+  public void shouldContextReturnMappersActualType() {
+    final ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("classpath:org/mybatis/spring/submitted/mappertype/applicationContext.xml");
+    try {
+      final IFooMapper mapper = ctx.getBean(IFooMapper.class);
+      assertNotNull("mapper must not be null", mapper);
+      assertThat("mapper should be a proxy", mapper, instanceOf(Proxy.class));
+
+      final Collection<Proxy> proxies = ctx.getBeansOfType(Proxy.class).values();
+      final Matcher<Proxy> mapperMatcher = instanceOf(IFooMapper.class);
+      assertThat("collection of all proxies should contain mapper", proxies, hasItem(mapperMatcher));
+    } finally {
+      ctx.close();
+    }
+  }
+
+}

--- a/src/test/java/org/mybatis/spring/submitted/mappertype/applicationContext.xml
+++ b/src/test/java/org/mybatis/spring/submitted/mappertype/applicationContext.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">
+
+  <jdbc:embedded-database id="dataSourceFoo" />
+
+  <bean id="sqlSessionFactoryFoo" class="org.mybatis.spring.SqlSessionFactoryBean">
+    <property name="dataSource" ref="dataSourceFoo" />
+  </bean>
+
+  <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+    <property name="basePackage" value="org.mybatis.spring.submitted.mappertype" />
+    <property name="sqlSessionFactoryBeanName" value="sqlSessionFactoryFoo" />
+  </bean>
+</beans>


### PR DESCRIPTION
So, reason: We use custom MapperProxyFactory and add several interfaces to created proxies. But we can't query spring to return such instances, because it checks only agains the type returned by FactoryBean#getObjectType.