### PR TITLE
Add SqlSessionFactoryBeanName annotation

### DIFF
--- a/src/main/java/org/mybatis/spring/mapper/SqlSessionFactoryBeanName.java
+++ b/src/main/java/org/mybatis/spring/mapper/SqlSessionFactoryBeanName.java
@@ -1,0 +1,13 @@
+package org.mybatis.spring.mapper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SqlSessionFactoryBeanName
+{
+    public String value() default "sqlSessionFactory";
+}


### PR DESCRIPTION
add SqlSessionFactoryBeanName annotation for dynamic assigning sqlSessionFactory to mapper interface.
