### PR TITLE
Updated POM dependencies & cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2010-2013 the original author or authors.
+  Copyright 2010-2014 the original author or authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>20</version>
+    <version>21</version>
   </parent>
 
   <artifactId>mybatis-spring</artifactId>
@@ -97,7 +98,7 @@
 
   <properties>
     <findbugs.onlyAnalyze>org.mybatis.spring.*,org.mybatis.spring.mapper.*,org.mybatis.spring.support.*,org.mybatis.spring.transaction.*</findbugs.onlyAnalyze>
-    <spring.version>3.1.4.RELEASE</spring.version>
+    <spring.version>3.2.8.RELEASE</spring.version>
     <clirr.comparisonVersion>1.2.1</clirr.comparisonVersion>
     <gcu.product>Spring</gcu.product>
     <osgi.import>org.springframework.batch.*;resolution:=optional,*</osgi.import>
@@ -109,10 +110,16 @@
     <dependency>
       <groupId>org.mybatis</groupId>
       <artifactId>mybatis</artifactId>
-      <version>3.2.3</version>
+      <version>3.2.6</version>
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${spring.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
@@ -123,25 +130,25 @@
     <dependency>
       <groupId>org.springframework.batch</groupId>
       <artifactId>spring-batch-infrastructure</artifactId>
-      <version>2.2.2.RELEASE</version>
+      <version>2.2.5.RELEASE</version>
       <scope>provided</scope>
     </dependency>
 
     <!-- Test dependencies -->
 
-	<dependency>
-		<groupId>com.atomikos</groupId>
-		<artifactId>transactions-jdbc</artifactId>
-		<version>3.9.0</version>
-		<scope>test</scope>
-	</dependency>
+    <dependency>
+      <groupId>com.atomikos</groupId>
+      <artifactId>transactions-jdbc</artifactId>
+      <version>3.9.3</version>
+      <scope>test</scope>
+    </dependency>
 
-	<dependency>
-		<groupId>org.apache.derby</groupId>
-		<artifactId>derby</artifactId>
-		<version>10.10.1.1</version>
-		<scope>test</scope>
-	</dependency>		
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
+      <version>10.10.1.1</version>
+      <scope>test</scope>
+    </dependency>		
 
     <dependency>
       <groupId>ognl</groupId>
@@ -167,7 +174,7 @@
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman-bmunit</artifactId>
-      <version>2.1.3</version>
+      <version>2.1.4.1</version>
       <scope>test</scope>
     </dependency>
             
@@ -181,7 +188,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2</version>
       <scope>test</scope>
     </dependency>
 
@@ -190,28 +197,6 @@
       <artifactId>log4j</artifactId>
       <version>1.2.17</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.sun.jdmk</groupId>
-          <artifactId>jmxtools</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.sun.jmx</groupId>
-          <artifactId>jmxri</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.jms</groupId>
-          <artifactId>jms</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.mail</groupId>
-          <artifactId>mail</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -267,6 +252,10 @@
         <exclusion>
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Fixed line ending on line 1 to match others
Updated copyright year
Updated xsd location to prevent redirect
Updated to mybatis-parent 21
Updated spring to 3.2.8
Updated mybatis to 3.2.6
Added spring-context directly to fix issues with dependency resolution
due to spring pom changes
Updated spring-batch to 2.2.5
Updated transactions-jdbc to 3.9.3
Updated byteman-bmunit to 2.1.4.1
Updated hsqldb to 2.3.2
Replaced tags in transaction-jdbc & derby with spaces to match POM
format
Removed all exclusions on log4j 1.2.17 - that affected version 1.2.15
and prior only.
Added another exclusion mockrunner for commons-logging.
