### PR TITLE
POM Updates / Minor Sonar corrections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,14 +21,14 @@
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>21</version>
+    <version>22-SNAPSHOT</version>
   </parent>
 
   <artifactId>mybatis-spring</artifactId>
   <version>1.2.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>MyBatis-Spring</name>
+  <name>mybatis-spring</name>
   <description>An easy-to-use Spring3 bridge for MyBatis sql mapping framework.</description>
   <url>http://www.mybatis.org/spring/</url>
 
@@ -98,7 +98,7 @@
 
   <properties>
     <findbugs.onlyAnalyze>org.mybatis.spring.*,org.mybatis.spring.mapper.*,org.mybatis.spring.support.*,org.mybatis.spring.transaction.*</findbugs.onlyAnalyze>
-    <spring.version>3.2.8.RELEASE</spring.version>
+    <spring.version>3.2.9.RELEASE</spring.version>
     <clirr.comparisonVersion>1.2.1</clirr.comparisonVersion>
     <gcu.product>Spring</gcu.product>
     <osgi.import>org.springframework.batch.*;resolution:=optional,*</osgi.import>
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>org.mybatis</groupId>
       <artifactId>mybatis</artifactId>
-      <version>3.2.6</version>
+      <version>3.2.7</version>
       <scope>provided</scope>
     </dependency>
 
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>org.springframework.batch</groupId>
       <artifactId>spring-batch-infrastructure</artifactId>
-      <version>2.2.5.RELEASE</version>
+      <version>2.2.7.RELEASE</version>
       <scope>provided</scope>
     </dependency>
 
@@ -146,21 +146,21 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.10.1.1</version>
+      <version>10.10.2.0</version>
       <scope>test</scope>
     </dependency>		
 
     <dependency>
       <groupId>ognl</groupId>
       <artifactId>ognl</artifactId>
-      <version>2.6.9</version>
+      <version>3.0.8</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
-      <version>2.2.2</version>
+      <version>3.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman-bmunit</artifactId>
-      <version>2.1.4.1</version>
+      <version>2.2.0.1</version>
       <scope>test</scope>
     </dependency>
             
@@ -270,7 +270,20 @@
 
   <build>
     <plugins>
-    
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <property>
+              <name>derby.stream.error.file</name>
+              <value>target/derby.log</value>
+            </property>
+        </systemProperties>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
@@ -282,7 +295,7 @@
 
     <resources>
       <resource>
-        <directory>${basedir}</directory>
+        <directory>${project.basedir}</directory>
         <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE</include>

--- a/src/main/java/org/mybatis/spring/batch/MyBatisBatchItemWriter.java
+++ b/src/main/java/org/mybatis/spring/batch/MyBatisBatchItemWriter.java
@@ -54,7 +54,7 @@ import org.springframework.dao.InvalidDataAccessResourceUsageException;
  */
 public class MyBatisBatchItemWriter<T> implements ItemWriter<T>, InitializingBean {
 
-  protected static final Log logger = LogFactory.getLog(MyBatisBatchItemWriter.class);
+  private static final Log logger = LogFactory.getLog(MyBatisBatchItemWriter.class);
 
   private SqlSessionTemplate sqlSessionTemplate;
 

--- a/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
+++ b/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
@@ -212,14 +212,14 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
    */
   @Override
   protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
-    return (beanDefinition.getMetadata().isInterface() && beanDefinition.getMetadata().isIndependent());
+    return beanDefinition.getMetadata().isInterface() && beanDefinition.getMetadata().isIndependent();
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  protected boolean checkCandidate(String beanName, BeanDefinition beanDefinition) throws IllegalStateException {
+  protected boolean checkCandidate(String beanName, BeanDefinition beanDefinition) {
     if (super.checkCandidate(beanName, beanDefinition)) {
       return true;
     } else {

--- a/src/main/java/org/mybatis/spring/mapper/MapperFactoryBean.java
+++ b/src/main/java/org/mybatis/spring/mapper/MapperFactoryBean.java
@@ -95,9 +95,9 @@ public class MapperFactoryBean<T> extends SqlSessionDaoSupport implements Factor
     if (this.addToConfig && !configuration.hasMapper(this.mapperInterface)) {
       try {
         configuration.addMapper(this.mapperInterface);
-      } catch (Throwable t) {
-        logger.error("Error while adding the mapper '" + this.mapperInterface + "' to configuration.", t);
-        throw new IllegalArgumentException(t);
+      } catch (Exception e) {
+        logger.error("Error while adding the mapper '" + this.mapperInterface + "' to configuration.", e);
+        throw new IllegalArgumentException(e);
       } finally {
         ErrorContext.instance().reset();
       }

--- a/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
+++ b/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
@@ -296,7 +296,7 @@ public class MapperScannerConfigurer implements BeanDefinitionRegistryPostProces
    * 
    * @since 1.0.2
    */
-  public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+  public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) {
     if (this.processPropertyPlaceHolders) {
       processPropertyPlaceHolders();
     }

--- a/src/test/java/org/mybatis/spring/SqlSessionFactoryBeanTest.java
+++ b/src/test/java/org/mybatis/spring/SqlSessionFactoryBeanTest.java
@@ -47,7 +47,8 @@ import com.mockrunner.mock.jdbc.MockDataSource;
  */
 public final class SqlSessionFactoryBeanTest {
 
-  private static final class TestObjectFactory extends DefaultObjectFactory {}
+  private static final class TestObjectFactory extends DefaultObjectFactory {
+    private static final long serialVersionUID = 1L;}
   private static final class TestObjectWrapperFactory extends DefaultObjectWrapperFactory {}
 
   private static MockDataSource dataSource = new MockDataSource();

--- a/src/test/java/org/mybatis/spring/support/SqlSessionDaoSupportTest.java
+++ b/src/test/java/org/mybatis/spring/support/SqlSessionDaoSupportTest.java
@@ -81,7 +81,7 @@ public final class SqlSessionDaoSupportTest extends AbstractMyBatisSpringTest {
     sqlSessionDaoSupport.afterPropertiesSet();
   }
 
-  @Test(expected = org.springframework.beans.factory.BeanCreationException.class)
+  @Test(expected = BeanCreationException.class)
   public void testAutowireWithNoFactoryOrSession() {
     setupContext();
     startContext();


### PR DESCRIPTION
Use mybatis parent 22-SNAPSHOT
Change <name> to match <artifactId> so import to myEclipse works as
expected
Updated spring to 3.2.9
Updated mybatis to 3.2.7
Updated spring batch to 2.2.7
Updated derby to 10.10.2.0
Updated ognl to 3.0.8 to match upcoming mybatis
Updated cglib to 3.1 to match upcoming mybatis
Updated byteman-bmunit to 2.2.0.1
Change location of derby.log to target/
Replace ${basedir} with ${project.basedir} as former is deprecated.

Minor cleanups based on sonar findings of project.
