### PR TITLE
Custom FactoryBean on MapperScan annotation

### DIFF
--- a/src/main/java/org/mybatis/spring/annotation/MapperScan.java
+++ b/src/main/java/org/mybatis/spring/annotation/MapperScan.java
@@ -61,7 +61,7 @@ import org.springframework.context.annotation.Import;
  *
  * @author Michael Lanyon
  * @author Eduardo Macarron
- * 
+ *
  * @since 1.2.0
  * @see MapperScannerRegistrar
  * @see MapperFactoryBean
@@ -101,7 +101,7 @@ public @interface MapperScan {
    * within the Spring container.
    */
   Class<? extends BeanNameGenerator> nameGenerator() default BeanNameGenerator.class;
-  
+
   /**
    * This property specifies the annotation that the scanner will search for.
    * <p>
@@ -135,5 +135,11 @@ public @interface MapperScan {
    * have more than one datasource.
    */
   String sqlSessionFactoryRef() default "";
+
+  /**
+   * Specifies a custom MapperFactoryBean to return a mybatis proxy as spring bean.
+   *
+   */
+  Class<? extends MapperFactoryBean> factoryBean() default MapperFactoryBean.class;
 
 }

--- a/src/main/java/org/mybatis/spring/annotation/MapperScannerRegistrar.java
+++ b/src/main/java/org/mybatis/spring/annotation/MapperScannerRegistrar.java
@@ -79,6 +79,11 @@ public class MapperScannerRegistrar implements ImportBeanDefinitionRegistrar, Re
       scanner.setBeanNameGenerator(BeanUtils.instantiateClass(generatorClass));
     }
 
+    Class<? extends MapperFactoryBean> mapperFactoryBeanClass = annoAttrs.getClass("factoryBean");
+    if (!MapperFactoryBean.class.equals(mapperFactoryBeanClass)) {
+      scanner.setMapperFactoryBean(BeanUtils.instantiateClass(mapperFactoryBeanClass));
+    }
+
     scanner.setSqlSessionTemplateBeanName(annoAttrs.getString("sqlSessionTemplateRef"));
     scanner.setSqlSessionFactoryBeanName(annoAttrs.getString("sqlSessionFactoryRef"));
 

--- a/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
+++ b/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2010-2015 the original author or authors.
+/*
+ *    Copyright 2010-2013 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -70,6 +70,8 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
 
   private Class<?> markerInterface;
 
+  private MapperFactoryBean mapperFactoryBean = new MapperFactoryBean();
+
   public ClassPathMapperScanner(BeanDefinitionRegistry registry) {
     super(registry, false);
   }
@@ -101,6 +103,11 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
   public void setSqlSessionFactoryBeanName(String sqlSessionFactoryBeanName) {
     this.sqlSessionFactoryBeanName = sqlSessionFactoryBeanName;
   }
+
+  public void setMapperFactoryBean(MapperFactoryBean mapperFactoryBean) {
+    this.mapperFactoryBean = (mapperFactoryBean != null ? mapperFactoryBean : new MapperFactoryBean());
+  }
+
 
   /**
    * Configures parent scanner to search for the right interfaces. It can search
@@ -177,8 +184,8 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
 
       // the mapper interface is the original class of the bean
       // but, the actual class of the bean is MapperFactoryBean
-      definition.getConstructorArgumentValues().addGenericArgumentValue(definition.getBeanClassName());
-      definition.setBeanClass(MapperFactoryBean.class);
+      definition.getPropertyValues().add("mapperInterface", definition.getBeanClassName());
+      definition.setBeanClass(this.mapperFactoryBean.getClass());
 
       definition.getPropertyValues().add("addToConfig", this.addToConfig);
 

--- a/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
+++ b/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2013 the original author or authors.
+ *    Copyright 2010-2015 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/spring/mapper/MapperFactoryBean.java
+++ b/src/main/java/org/mybatis/spring/mapper/MapperFactoryBean.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2010-2015 the original author or authors.
+/*
+ *    Copyright 2010-2012 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public class MapperFactoryBean<T> extends SqlSessionDaoSupport implements Factor
   public MapperFactoryBean() {
   }
 
-    /**
+  /**
    * Sets the mapper interface of the MyBatis mapper
    *
    * @param mapperInterface class of the interface
@@ -115,7 +115,6 @@ public class MapperFactoryBean<T> extends SqlSessionDaoSupport implements Factor
   /**
    * {@inheritDoc}
    */
-  @Override
   public T getObject() throws Exception {
     return getSqlSession().getMapper(this.mapperInterface);
   }
@@ -123,7 +122,6 @@ public class MapperFactoryBean<T> extends SqlSessionDaoSupport implements Factor
   /**
    * {@inheritDoc}
    */
-  @Override
   public Class<T> getObjectType() {
     return this.mapperInterface;
   }
@@ -131,9 +129,26 @@ public class MapperFactoryBean<T> extends SqlSessionDaoSupport implements Factor
   /**
    * {@inheritDoc}
    */
-  @Override
   public boolean isSingleton() {
     return true;
   }
 
+  //------------- mutators --------------
+
+  /**
+   * Return the mapper interface of the MyBatis mapper
+   * @return class of the interface
+   */
+  public Class<T> getMapperInterface() {
+    return mapperInterface;
+  }
+
+  /**
+   * Return the flag for addition into MyBatis config.
+   * @return true if the mapper will be added to MyBatis in the case it is not already
+   * registered.
+   */
+  public boolean isAddToConfig() {
+    return addToConfig;
+  }
 }

--- a/src/main/java/org/mybatis/spring/mapper/MapperFactoryBean.java
+++ b/src/main/java/org/mybatis/spring/mapper/MapperFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2010-2012 the original author or authors.
+ *    Copyright 2010-2015 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import org.springframework.beans.factory.FactoryBean;
  * Note that this factory can only inject <em>interfaces</em>, not concrete classes.
  *
  * @author Eduardo Macarron
- * 
+ *
  * @see SqlSessionTemplate
  * @version $Id$
  */
@@ -64,30 +64,6 @@ public class MapperFactoryBean<T> extends SqlSessionDaoSupport implements Factor
   }
 
   public MapperFactoryBean() {
-  }
-
-  /**
-   * Sets the mapper interface of the MyBatis mapper
-   *
-   * @param mapperInterface class of the interface
-   */
-  public void setMapperInterface(Class<T> mapperInterface) {
-    this.mapperInterface = mapperInterface;
-  }
-
-  /**
-   * If addToConfig is false the mapper will not be added to MyBatis. This means
-   * it must have been included in mybatis-config.xml.
-   * <p>
-   * If it is true, the mapper will be added to MyBatis in the case it is not already
-   * registered.
-   * <p>
-   * By default addToCofig is true.
-   *
-   * @param addToConfig
-   */
-  public void setAddToConfig(boolean addToConfig) {
-    this.addToConfig = addToConfig;
   }
 
   /**
@@ -136,7 +112,17 @@ public class MapperFactoryBean<T> extends SqlSessionDaoSupport implements Factor
   //------------- mutators --------------
 
   /**
+   * Sets the mapper interface of the MyBatis mapper
+   *
+   * @param mapperInterface class of the interface
+   */
+  public void setMapperInterface(Class<T> mapperInterface) {
+    this.mapperInterface = mapperInterface;
+  }
+
+  /**
    * Return the mapper interface of the MyBatis mapper
+   *
    * @return class of the interface
    */
   public Class<T> getMapperInterface() {
@@ -144,7 +130,23 @@ public class MapperFactoryBean<T> extends SqlSessionDaoSupport implements Factor
   }
 
   /**
+   * If addToConfig is false the mapper will not be added to MyBatis. This means
+   * it must have been included in mybatis-config.xml.
+   * <p/>
+   * If it is true, the mapper will be added to MyBatis in the case it is not already
+   * registered.
+   * <p/>
+   * By default addToCofig is true.
+   *
+   * @param addToConfig
+   */
+  public void setAddToConfig(boolean addToConfig) {
+    this.addToConfig = addToConfig;
+  }
+
+  /**
    * Return the flag for addition into MyBatis config.
+   *
    * @return true if the mapper will be added to MyBatis in the case it is not already
    * registered.
    */

--- a/src/test/java/org/mybatis/spring/annotation/MapperScanTest.java
+++ b/src/test/java/org/mybatis/spring/annotation/MapperScanTest.java
@@ -15,9 +15,6 @@
  */
 package org.mybatis.spring.annotation;
 
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,6 +24,7 @@ import org.mybatis.spring.mapper.AnnotatedMapper;
 import org.mybatis.spring.mapper.MapperInterface;
 import org.mybatis.spring.mapper.MapperSubinterface;
 import org.mybatis.spring.mapper.child.MapperChildInterface;
+import org.mybatis.spring.type.DummyMapperFactoryBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConstructorArgumentValues;
@@ -38,6 +36,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 import com.mockrunner.mock.jdbc.MockDataSource;
+
+import static org.junit.Assert.*;
 
 /**
  * Test for the MapperScannerRegistrar.
@@ -163,6 +163,22 @@ public final class MapperScanTest {
   }
 
   @Test
+  public void testCustomMapperFactoryBean() {
+    applicationContext.register(AppConfigWithCustomMapperFactoryBean.class);
+
+    startContext();
+
+    // all interfaces with methods should be loaded
+    applicationContext.getBean("mapperInterface");
+    applicationContext.getBean("mapperSubinterface");
+    applicationContext.getBean("mapperChildInterface");
+    applicationContext.getBean("annotatedMapper");
+
+    assertTrue(DummyMapperFactoryBean.getMapperCount() > 0);
+
+  }
+
+  @Test
   public void testScanWithNameConflict() {
     GenericBeanDefinition definition = new GenericBeanDefinition();
     definition.setBeanClass(Object.class);
@@ -263,6 +279,11 @@ public final class MapperScanTest {
   @Configuration
   @MapperScan(basePackages = "org.mybatis.spring.mapper", nameGenerator = MapperScanTest.BeanNameGenerator.class)
   public static class AppConfigWithNameGenerator {
+  }
+
+  @Configuration
+  @MapperScan(basePackages = "org.mybatis.spring.mapper", factoryBean = DummyMapperFactoryBean.class)
+  public static class AppConfigWithCustomMapperFactoryBean {
   }
 
   public static class BeanNameGenerator implements org.springframework.beans.factory.support.BeanNameGenerator {

--- a/src/test/java/org/mybatis/spring/type/DummyMapperFactoryBean.java
+++ b/src/test/java/org/mybatis/spring/type/DummyMapperFactoryBean.java
@@ -1,0 +1,62 @@
+package org.mybatis.spring.type;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.log4j.Logger;
+import org.mybatis.spring.mapper.MapperFactoryBean;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DummyMapperFactoryBean<T> extends MapperFactoryBean<T> {
+
+  private static final Logger LOGGER = Logger.getLogger(DummyMapperFactoryBean.class);
+
+  private static final AtomicInteger mapperInstanceCount = new AtomicInteger(0);
+
+  @Override
+  protected void checkDaoConfig() {
+    super.checkDaoConfig();
+    // make something more
+    if (isAddToConfig()) {
+      LOGGER.debug("register mapper for interface : " + getMapperInterface());
+
+    }
+  }
+
+  @Override
+  public T getObject() throws Exception {
+    MapperFactoryBean<T> mapperFactoryBean = new MapperFactoryBean<T>();
+    mapperFactoryBean.setMapperInterface(getMapperInterface());
+    mapperFactoryBean.setAddToConfig(isAddToConfig());
+    mapperFactoryBean.setSqlSessionFactory(getCustomSessionFactoryForClass(getMapperInterface()));
+    T object = mapperFactoryBean.getObject();
+    mapperInstanceCount.incrementAndGet();
+    return object;
+  }
+
+
+
+  private SqlSessionFactory getCustomSessionFactoryForClass(Class mapperClass) {
+    // can for example read a custom annotation to set a custom sqlSessionFactory
+
+    // just a dummy implementation example
+    return (SqlSessionFactory) Proxy.newProxyInstance(
+        SqlSessionFactory.class.getClassLoader(),
+        new Class[]{SqlSessionFactory.class},
+        new InvocationHandler() {
+          public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if ("getConfiguration".equals(method.getName())) {
+              return getSqlSession().getConfiguration();
+            }
+            // dummy
+            return null;
+          }
+        });
+  }
+
+  public static final int getMapperCount(){
+    return mapperInstanceCount.get();
+  }
+}


### PR DESCRIPTION
Hi !!
Can you have a look to this little contribution :-)

## Use case
We want to use our custom annotation on mapper interfaces to select the correct datasource at bean creation phase. Our datasource instances are not present in spring context.

## Problem
We use several datasources for our application but we want to scan all our mapper by convention with a spring java config. I see some attribute like *sqlSessionFactoryRef* or *sqlSessionTemplateRef* but with this, we have to declare a sqlSessionFactory for each datasource and declare a MapperScan for each different database (or maybe i miss something).

## Resolve with this PR
We will be able to use this:
```java
@MapperScan(basePackages = "org.mybatis.spring.mapper", factoryBean = OurCustomFactoryBean.class)
```
*OurCustomFactoryBean* will override *getObject()* to choose the right datasource and return a mapper proxy with the selected sqlSessionFactory. The session factory is built by some custom internal stuffs.

