### PR TITLE
Modify to use a custom VFS when scanning type aliases on SqlSessionFactoryBean

### DIFF
--- a/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
+++ b/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
@@ -388,6 +388,10 @@ public class SqlSessionFactoryBean implements FactoryBean<SqlSessionFactory>, In
       configuration.setObjectWrapperFactory(this.objectWrapperFactory);
     }
 
+    if (this.vfs != null) {
+      configuration.setVfsImpl(this.vfs);
+    }
+
     if (hasLength(this.typeAliasesPackage)) {
       String[] typeAliasPackageArray = tokenizeToStringArray(this.typeAliasesPackage,
           ConfigurableApplicationContext.CONFIG_LOCATION_DELIMITERS);
@@ -444,10 +448,6 @@ public class SqlSessionFactoryBean implements FactoryBean<SqlSessionFactory>, In
       } catch (SQLException e) {
         throw new NestedIOException("Failed getting a databaseId", e);
       }
-    }
-
-    if (this.vfs != null) {
-      configuration.setVfsImpl(this.vfs);
     }
 
     if (xmlConfigBuilder != null) {


### PR DESCRIPTION
(cherry picked from commit 8c92989a34f531243761ed783e39057c33a7dd50)

I've backported #119(#120) to 1.2.x.
