### PR TITLE
Upgrade to Atomikos 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <dependency>
       <groupId>com.atomikos</groupId>
       <artifactId>transactions-jdbc</artifactId>
-      <version>3.9.3</version>
+      <version>4.0.2</version>
       <scope>test</scope>
     </dependency>
 
@@ -269,6 +269,10 @@
             <property>
               <name>derby.stream.error.file</name>
               <value>${project.build.directory}/derby.log</value>
+            </property>
+            <property>
+              <name>com.atomikos.icatch.log_base_dir</name>
+              <value>${project.build.directory}</value>
             </property>
         </systemProperties>
         </configuration>


### PR DESCRIPTION
Please review.

**Note:**
An atomikos transaction log file(such as `tmlog0.log`) on root directory is unnecessary by this change.
Please MyBatis developer remove its file on local machine.
And In this change, transaction log file will output to the build directory(`./target`).