### PR TITLE
Polish to use ConfigurableApplicationContext instead of AbstractApplicationContext #144

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <version>3.0.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
+++ b/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
@@ -37,7 +37,6 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.util.StringUtils;
 
 /**
@@ -328,8 +327,8 @@ public class MapperScannerConfigurer implements BeanDefinitionRegistryPostProces
   private void processPropertyPlaceHolders() {
     Map<String, PropertyResourceConfigurer> prcs = applicationContext.getBeansOfType(PropertyResourceConfigurer.class);
 
-    if (!prcs.isEmpty() && applicationContext instanceof AbstractApplicationContext) {
-      BeanDefinition mapperScannerBean = ((AbstractApplicationContext) applicationContext)
+    if (!prcs.isEmpty() && applicationContext instanceof ConfigurableApplicationContext) {
+      BeanDefinition mapperScannerBean = ((ConfigurableApplicationContext) applicationContext)
           .getBeanFactory().getBeanDefinition(beanName);
 
       // PropertyResourceConfigurer does not expose any methods to explicitly perform


### PR DESCRIPTION
@harawata 

I've polished to use `ConfigurableApplicationContext`(interface) instead of `AbstractApplicationContext`(abstract class).
I think it should be independent on the specific class or abstract class.

What do you think ?

#144 