### PR TITLE
Retain annotations on mapper object

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>1.4.15</version>
+    </dependency>
+
     <!-- Test dependencies -->
 
     <dependency>

--- a/src/test/java/org/mybatis/spring/TestMapper.java
+++ b/src/test/java/org/mybatis/spring/TestMapper.java
@@ -15,10 +15,17 @@
  */
 package org.mybatis.spring;
 
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
 public interface TestMapper {
 
   int findTest();
 
   void insertTest(String test);
+
+  @Cacheable
+  void annotatedMethod();
 
 }


### PR DESCRIPTION
Mapper object returned by MapperFactoryBean.getObject() doesn't carry annotations present on mapper interface. As a result, it's not possible to use Spring BeanPostProcessors operating on annotations to add additional logic (e.g metrics via ryantenney/metrics-spring). This pull request solves this by generating class, which implements mapper interface and carries all annotations.