### PR TITLE
Add comment about atomikos version limitation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
 
     <!-- Test dependencies -->
 
+    <!-- Using version 4.0.3, versions higher require only jdk7 -->
     <dependency>
       <groupId>com.atomikos</groupId>
       <artifactId>transactions-jdbc</artifactId>


### PR DESCRIPTION
Atomikos 4.0.4+ is required Java 7+.