### PR TITLE
Fix to close the ApplicationContext at assertion failing

### DIFF
--- a/src/test/java/org/mybatis/spring/annotation/MapperScanTest.java
+++ b/src/test/java/org/mybatis/spring/annotation/MapperScanTest.java
@@ -70,15 +70,17 @@ public final class MapperScanTest {
 
   @AfterEach
   void assertNoMapperClass() {
-    // concrete classes should always be ignored by MapperScannerPostProcessor
-    assertBeanNotLoaded("mapperClass");
+    try {
+      // concrete classes should always be ignored by MapperScannerPostProcessor
+      assertBeanNotLoaded("mapperClass");
 
-    // no method interfaces should be ignored too
-    assertBeanNotLoaded("package-info");
-    // assertBeanNotLoaded("annotatedMapperZeroMethods"); // as of 1.1.0 mappers
-    // with no methods are loaded
-
-    applicationContext.close();
+      // no method interfaces should be ignored too
+      assertBeanNotLoaded("package-info");
+      // assertBeanNotLoaded("annotatedMapperZeroMethods"); // as of 1.1.0 mappers
+      // with no methods are loaded
+    } finally {
+      applicationContext.close();
+    }
   }
 
   @Test

--- a/src/test/java/org/mybatis/spring/config/NamespaceTest.java
+++ b/src/test/java/org/mybatis/spring/config/NamespaceTest.java
@@ -56,15 +56,17 @@ public final class NamespaceTest {
 
   @AfterEach
   void assertNoMapperClass() {
-    // concrete classes should always be ignored by MapperScannerPostProcessor
-    assertBeanNotLoaded("mapperClass");
+    try {
+      // concrete classes should always be ignored by MapperScannerPostProcessor
+      assertBeanNotLoaded("mapperClass");
 
-    // no method interfaces should be ignored too
-    assertBeanNotLoaded("package-info");
-    // assertBeanNotLoaded("annotatedMapperZeroMethods"); // as of 1.1.0 mappers
-    // with no methods are loaded
-
-    applicationContext.close();
+      // no method interfaces should be ignored too
+      assertBeanNotLoaded("package-info");
+      // assertBeanNotLoaded("annotatedMapperZeroMethods"); // as of 1.1.0 mappers
+      // with no methods are loaded
+    } finally {
+      applicationContext.close();
+    }
   }
 
   @Test

--- a/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
+++ b/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
@@ -71,14 +71,16 @@ public final class MapperScannerConfigurerTest {
 
   @AfterEach
   void assertNoMapperClass() {
-    // concrete classes should always be ignored by MapperScannerPostProcessor
-    assertBeanNotLoaded("mapperClass");
+    try {
+      // concrete classes should always be ignored by MapperScannerPostProcessor
+      assertBeanNotLoaded("mapperClass");
 
-    // no method interfaces should be ignored too
-    assertBeanNotLoaded("package-info");
-    //        assertBeanNotLoaded("annotatedMapperZeroMethods"); // as of 1.1.0 mappers with no methods are loaded
-    
-    applicationContext.close();
+      // no method interfaces should be ignored too
+      assertBeanNotLoaded("package-info");
+      //        assertBeanNotLoaded("annotatedMapperZeroMethods"); // as of 1.1.0 mappers with no methods are loaded
+    } finally {
+      applicationContext.close();
+    }
   }
 
   @Test


### PR DESCRIPTION
In the current implementation, if an assertion is failing, `ApplicationContext` does not close.