### PR TITLE
Allow repeatable for @MapperScan

### DIFF
--- a/src/main/java/org/mybatis/spring/annotation/MapperScan.java
+++ b/src/main/java/org/mybatis/spring/annotation/MapperScan.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2016 the original author or authors.
+ *    Copyright 2010-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.mybatis.spring.annotation;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -70,6 +71,7 @@ import org.springframework.context.annotation.Import;
 @Target(ElementType.TYPE)
 @Documented
 @Import(MapperScannerRegistrar.class)
+@Repeatable(MapperScans.class)
 public @interface MapperScan {
 
   /**

--- a/src/main/java/org/mybatis/spring/annotation/MapperScans.java
+++ b/src/main/java/org/mybatis/spring/annotation/MapperScans.java
@@ -1,0 +1,44 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.spring.annotation;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The Container annotation that aggregates several {@link MapperScan} annotations.
+ *
+ * <p>Can be used natively, declaring several nested {@link MapperScan} annotations.
+ * Can also be used in conjunction with Java 8's support for repeatable annotations,
+ * where {@link MapperScan} can simply be declared several times on the same method,
+ * implicitly generating this container annotation.
+ *
+ * @author Kazuki Shimizu
+ * @since 2.0.0
+ * @see MapperScan
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+@Import(MapperScannerRegistrar.RepeatingRegistrar.class)
+public @interface MapperScans {
+  MapperScan[] value();
+}

--- a/src/test/java/org/mybatis/spring/annotation/MapperScanTest.java
+++ b/src/test/java/org/mybatis/spring/annotation/MapperScanTest.java
@@ -245,6 +245,26 @@ public final class MapperScanTest {
     
   }
 
+  @Test
+  void testScanWithMapperScanIsRepeat() {
+    applicationContext.register(AppConfigWithMapperScanIsRepeat.class);
+
+    startContext();
+
+    applicationContext.getBean("ds1Mapper");
+    applicationContext.getBean("ds2Mapper");
+  }
+
+  @Test
+  void testScanWithMapperScans() {
+    applicationContext.register(AppConfigWithMapperScans.class);
+
+    startContext();
+
+    applicationContext.getBean("ds1Mapper");
+    applicationContext.getBean("ds2Mapper");
+  }
+
   @Configuration
   @MapperScan("org.mybatis.spring.mapper")
   public static class AppConfigWithPackageScan {
@@ -288,6 +308,20 @@ public final class MapperScanTest {
   @Configuration
   @MapperScan(basePackages = "org.mybatis.spring.mapper", factoryBean = DummyMapperFactoryBean.class)
   public static class AppConfigWithCustomMapperFactoryBean {
+  }
+
+  @Configuration
+  @MapperScan(basePackages = "org.mybatis.spring.annotation.mapper.ds1")
+  @MapperScan(basePackages = "org.mybatis.spring.annotation.mapper.ds2")
+  public static class AppConfigWithMapperScanIsRepeat {
+  }
+
+  @Configuration
+  @MapperScans({
+      @MapperScan(basePackages = "org.mybatis.spring.annotation.mapper.ds1")
+      ,@MapperScan(basePackages = "org.mybatis.spring.annotation.mapper.ds2")
+  })
+  public static class AppConfigWithMapperScans {
   }
 
   public static class BeanNameGenerator implements org.springframework.beans.factory.support.BeanNameGenerator {

--- a/src/test/java/org/mybatis/spring/annotation/mapper/ds1/Ds1Mapper.java
+++ b/src/test/java/org/mybatis/spring/annotation/mapper/ds1/Ds1Mapper.java
@@ -1,0 +1,19 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.spring.annotation.mapper.ds1;
+
+public interface Ds1Mapper {
+}

--- a/src/test/java/org/mybatis/spring/annotation/mapper/ds2/Ds2Mapper.java
+++ b/src/test/java/org/mybatis/spring/annotation/mapper/ds2/Ds2Mapper.java
@@ -1,0 +1,19 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.spring.annotation.mapper.ds2;
+
+public interface Ds2Mapper {
+}


### PR DESCRIPTION
I will propose to allow a repeatable annotation supported by Java 8 on `@MapperScan` like `@ComponentScan` provided by Spring Framework.
What do you think?
