### PR TITLE
Add builder classes for ItemReader and ItemWriter

### DIFF
--- a/src/main/java/org/mybatis/spring/batch/builder/MyBatisBatchItemWriterBuilder.java
+++ b/src/main/java/org/mybatis/spring/batch/builder/MyBatisBatchItemWriterBuilder.java
@@ -1,0 +1,102 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.spring.batch.builder;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.mybatis.spring.batch.MyBatisBatchItemWriter;
+
+/**
+ * A builder for the {@link MyBatisBatchItemWriter}.
+ *
+ * @author Kazuki Shimizu
+ * @since 2.0.0
+ * @see MyBatisBatchItemWriter
+ */
+public class MyBatisBatchItemWriterBuilder<T> {
+
+  private SqlSessionTemplate sqlSessionTemplate;
+  private SqlSessionFactory sqlSessionFactory;
+  private String statementId;
+  private Boolean assertUpdates = true;
+
+  /**
+   * Set the {@link SqlSessionTemplate} to be used by writer for database access.
+   *
+   * @param sqlSessionTemplate the {@link SqlSessionTemplate} to be used by writer for database access
+   * @return this instance for method chaining
+   * @see MyBatisBatchItemWriter#setSqlSessionTemplate(SqlSessionTemplate)
+   */
+  public MyBatisBatchItemWriterBuilder<T> sqlSessionTemplate(
+      SqlSessionTemplate sqlSessionTemplate) {
+    this.sqlSessionTemplate = sqlSessionTemplate;
+    return this;
+  }
+
+  /**
+   * Set the {@link SqlSessionFactory} to be used by writer for database access.
+   *
+   * @param sqlSessionFactory the {@link SqlSessionFactory} to be used by writer for database access
+   * @return this instance for method chaining
+   * @see MyBatisBatchItemWriter#setSqlSessionFactory(SqlSessionFactory)
+   */
+  public MyBatisBatchItemWriterBuilder<T> sqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
+    this.sqlSessionFactory = sqlSessionFactory;
+    return this;
+  }
+
+  /**
+   * Set the statement id identifying the statement in the SqlMap configuration file.
+   *
+   * @param statementId the id for the statement
+   * @return this instance for method chaining
+   * @see MyBatisBatchItemWriter#setStatementId(String)
+   */
+  public MyBatisBatchItemWriterBuilder<T> statementId(String statementId) {
+    this.statementId = statementId;
+    return this;
+  }
+
+  /**
+   * The flag that determines whether an assertion is made that all items cause at least one row to
+   * be updated.
+   *
+   * @param assertUpdates the flag to set. Defaults to true
+   * @return this instance for method chaining
+   * @see MyBatisBatchItemWriter#setAssertUpdates(boolean)
+   */
+  public MyBatisBatchItemWriterBuilder<T> assertUpdates(boolean assertUpdates) {
+    this.assertUpdates = assertUpdates;
+    return this;
+  }
+
+  /**
+   * Returns a fully built {@link MyBatisBatchItemWriter}.
+   *
+   * @return the writer
+   */
+  public MyBatisBatchItemWriter<T> build() {
+    MyBatisBatchItemWriter<T> writer = new MyBatisBatchItemWriter<>();
+    writer.setSqlSessionTemplate(this.sqlSessionTemplate);
+    writer.setSqlSessionFactory(this.sqlSessionFactory);
+    writer.setStatementId(this.statementId);
+    if (this.assertUpdates != null) {
+      writer.setAssertUpdates(this.assertUpdates);
+    }
+    return writer;
+  }
+
+}

--- a/src/main/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilder.java
+++ b/src/main/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilder.java
@@ -1,0 +1,119 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.spring.batch.builder;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.batch.MyBatisCursorItemReader;
+
+import java.util.Map;
+
+/**
+ * A builder for the {@link MyBatisCursorItemReader}.
+ *
+ * @author Kazuki Shimizu
+ * @since 2.0.0
+ * @see MyBatisCursorItemReader
+ */
+public class MyBatisCursorItemReaderBuilder<T> {
+
+  private SqlSessionFactory sqlSessionFactory;
+  private String queryId;
+  private Map<String, Object> parameterValues;
+  private Boolean saveState;
+  private Integer maxItemCount;
+
+  /**
+   * Set the {@link SqlSessionFactory} to be used by reader for database access.
+   *
+   * @param sqlSessionFactory the {@link SqlSessionFactory} to be used by writer for database access
+   * @return this instance for method chaining
+   * @see MyBatisCursorItemReader#setSqlSessionFactory(SqlSessionFactory)
+   */
+  public MyBatisCursorItemReaderBuilder<T> sqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
+    this.sqlSessionFactory = sqlSessionFactory;
+    return this;
+  }
+
+  /**
+   * Set the query id identifying the statement in the SqlMap configuration file.
+   *
+   * @param queryId the id for the query
+   * @return this instance for method chaining
+   * @see MyBatisCursorItemReader#setQueryId(String)
+   */
+  public MyBatisCursorItemReaderBuilder<T> queryId(String queryId) {
+    this.queryId = queryId;
+    return this;
+  }
+
+  /**
+   * Set the parameter values to be used for the query execution.
+   *
+   * @param parameterValues the parameter values to be used for the query execution
+   * @return this instance for method chaining
+   * @see MyBatisCursorItemReader#setParameterValues(Map)
+   */
+  public MyBatisCursorItemReaderBuilder<T> parameterValues(Map<String, Object> parameterValues) {
+    this.parameterValues = parameterValues;
+    return this;
+  }
+
+  /**
+   * Configure if the state of the {@link org.springframework.batch.item.ItemStreamSupport} should
+   * be persisted within the {@link org.springframework.batch.item.ExecutionContext} for restart
+   * purposes.
+   *
+   * @param saveState defaults to true
+   * @return The current instance of the builder.
+   * @see org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader#setSaveState(boolean)
+   */
+  public MyBatisCursorItemReaderBuilder<T> saveState(boolean saveState) {
+    this.saveState = saveState;
+    return this;
+  }
+
+  /**
+   * Configure the max number of items to be read.
+   *
+   * @param maxItemCount the max items to be read
+   * @return The current instance of the builder.
+   * @see org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader#setMaxItemCount(int)
+   */
+  public MyBatisCursorItemReaderBuilder<T> maxItemCount(int maxItemCount) {
+    this.maxItemCount = maxItemCount;
+    return this;
+  }
+
+  /**
+   * Returns a fully built {@link MyBatisCursorItemReader}.
+   *
+   * @return the reader
+   */
+  public MyBatisCursorItemReader<T> build() {
+    MyBatisCursorItemReader<T> reader = new MyBatisCursorItemReader<>();
+    reader.setSqlSessionFactory(this.sqlSessionFactory);
+    reader.setQueryId(this.queryId);
+    reader.setParameterValues(this.parameterValues);
+    if (this.saveState != null) {
+      reader.setSaveState(saveState);
+    }
+    if (this.maxItemCount != null) {
+      reader.setMaxItemCount(this.maxItemCount);
+    }
+    return reader;
+  }
+
+}

--- a/src/main/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilder.java
+++ b/src/main/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilder.java
@@ -1,0 +1,135 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.spring.batch.builder;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+
+import java.util.Map;
+
+/**
+ * A builder for the {@link MyBatisPagingItemReader}.
+ *
+ * @author Kazuki Shimizu
+ * @since 2.0.0
+ * @see MyBatisPagingItemReader
+ */
+public class MyBatisPagingItemReaderBuilder<T> {
+
+  private SqlSessionFactory sqlSessionFactory;
+  private String queryId;
+  private Map<String, Object> parameterValues;
+  private Integer pageSize;
+  private Boolean saveState;
+  private Integer maxItemCount;
+
+  /**
+   * Set the {@link SqlSessionFactory} to be used by writer for database access.
+   *
+   * @param sqlSessionFactory the {@link SqlSessionFactory} to be used by writer for database access
+   * @return this instance for method chaining
+   * @see MyBatisPagingItemReader#setSqlSessionFactory(SqlSessionFactory)
+   */
+  public MyBatisPagingItemReaderBuilder<T> sqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
+    this.sqlSessionFactory = sqlSessionFactory;
+    return this;
+  }
+
+  /**
+   * Set the query id identifying the statement in the SqlMap configuration file.
+   *
+   * @param queryId the id for the query
+   * @return this instance for method chaining
+   * @see MyBatisPagingItemReader#setQueryId(String)
+   */
+  public MyBatisPagingItemReaderBuilder<T> queryId(String queryId) {
+    this.queryId = queryId;
+    return this;
+  }
+
+  /**
+   * Set the parameter values to be used for the query execution.
+   *
+   * @param parameterValues the parameter values to be used for the query execution
+   * @return this instance for method chaining
+   * @see MyBatisPagingItemReader#setParameterValues(Map)
+   */
+  public MyBatisPagingItemReaderBuilder<T> parameterValues(Map<String, Object> parameterValues) {
+    this.parameterValues = parameterValues;
+    return this;
+  }
+
+  /**
+   * The number of records to request per page/query. Defaults to 10. Must be greater than zero.
+   *
+   * @param pageSize number of items
+   * @return this instance for method chaining
+   * @see org.springframework.batch.item.database.AbstractPagingItemReader#setPageSize(int)
+   */
+  public MyBatisPagingItemReaderBuilder<T> pageSize(int pageSize) {
+    this.pageSize = pageSize;
+    return this;
+  }
+
+  /**
+   * Configure if the state of the {@link org.springframework.batch.item.ItemStreamSupport} should
+   * be persisted within the {@link org.springframework.batch.item.ExecutionContext} for restart
+   * purposes.
+   *
+   * @param saveState defaults to true
+   * @return The current instance of the builder.
+   * @see org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader#setSaveState(boolean)
+   */
+  public MyBatisPagingItemReaderBuilder<T> saveState(boolean saveState) {
+    this.saveState = saveState;
+    return this;
+  }
+
+  /**
+   * Configure the max number of items to be read.
+   *
+   * @param maxItemCount the max items to be read
+   * @return The current instance of the builder.
+   * @see org.springframework.batch.item.support.AbstractItemCountingItemStreamItemReader#setMaxItemCount(int)
+   */
+  public MyBatisPagingItemReaderBuilder<T> maxItemCount(int maxItemCount) {
+    this.maxItemCount = maxItemCount;
+    return this;
+  }
+
+  /**
+   * Returns a fully built {@link MyBatisPagingItemReader}.
+   *
+   * @return the reader
+   */
+  public MyBatisPagingItemReader<T> build() {
+    MyBatisPagingItemReader<T> reader = new MyBatisPagingItemReader<>();
+    reader.setSqlSessionFactory(this.sqlSessionFactory);
+    reader.setQueryId(this.queryId);
+    reader.setParameterValues(this.parameterValues);
+    if (this.pageSize != null) {
+      reader.setPageSize(this.pageSize);
+    }
+    if (this.saveState != null) {
+      reader.setSaveState(saveState);
+    }
+    if (this.maxItemCount != null) {
+      reader.setMaxItemCount(this.maxItemCount);
+    }
+    return reader;
+  }
+
+}

--- a/src/main/java/org/mybatis/spring/batch/builder/package-info.java
+++ b/src/main/java/org/mybatis/spring/batch/builder/package-info.java
@@ -1,0 +1,22 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/**
+ * Contains classes to builder classes for {@link org.springframework.batch.item.ItemReader} and
+ * {@link org.springframework.batch.item.ItemWriter}.
+ *
+ * @since 2.0.0
+ */
+package org.mybatis.spring.batch.builder;

--- a/src/test/java/org/mybatis/spring/batch/builder/MyBatisBatchItemWriterBuilderTest.java
+++ b/src/test/java/org/mybatis/spring/batch/builder/MyBatisBatchItemWriterBuilderTest.java
@@ -1,0 +1,156 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.spring.batch.builder;
+
+import org.apache.ibatis.executor.BatchResult;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.mybatis.spring.batch.MyBatisBatchItemWriter;
+
+import javax.sql.DataSource;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for {@link MyBatisBatchItemWriterBuilder}.
+ *
+ * @since 2.0.0
+ * @author Kazuki Shimizu
+ */
+class MyBatisBatchItemWriterBuilderTest {
+
+  @Mock
+  private DataSource dataSource;
+
+  @Mock
+  private SqlSessionFactory sqlSessionFactory;
+
+  @Mock
+  private SqlSession sqlSession;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.initMocks(this);
+    {
+      Configuration configuration = new Configuration();
+      Environment environment =
+          new Environment("unittest", new JdbcTransactionFactory(), dataSource);
+      configuration.setEnvironment(environment);
+      Mockito.when(this.sqlSessionFactory.getConfiguration()).thenReturn(configuration);
+      Mockito.when(this.sqlSessionFactory.openSession(ExecutorType.BATCH))
+          .thenReturn(this.sqlSession);
+    }
+    {
+      BatchResult result = new BatchResult(null, null);
+      result.setUpdateCounts(new int[] {1});
+      Mockito.when(this.sqlSession.flushStatements()).thenReturn(Collections.singletonList(result));
+    }
+  }
+
+  @Test
+  void testConfigurationUsingSqlSessionFactory() {
+
+    // @formatter:off
+    MyBatisBatchItemWriter<Foo> itemWriter = new MyBatisBatchItemWriterBuilder<Foo>()
+            .sqlSessionFactory(this.sqlSessionFactory)
+            .statementId("updateFoo")
+            .build();
+    // @formatter:on
+    itemWriter.afterPropertiesSet();
+
+    List<Foo> foos = getFoos();
+
+    itemWriter.write(foos);
+
+    Mockito.verify(this.sqlSession).update("updateFoo", foos.get(0));
+    Mockito.verify(this.sqlSession).update("updateFoo", foos.get(1));
+    Mockito.verify(this.sqlSession).update("updateFoo", foos.get(2));
+
+  }
+
+  @Test
+  void testConfigurationUsingSqlSessionTemplate() {
+
+    // @formatter:off
+    MyBatisBatchItemWriter<Foo> itemWriter = new MyBatisBatchItemWriterBuilder<Foo>()
+            .sqlSessionTemplate(new SqlSessionTemplate(this.sqlSessionFactory, ExecutorType.BATCH))
+            .statementId("updateFoo")
+            .build();
+    // @formatter:on
+    itemWriter.afterPropertiesSet();
+
+    List<Foo> foos = getFoos();
+
+    itemWriter.write(foos);
+
+    Mockito.verify(this.sqlSession).update("updateFoo", foos.get(0));
+    Mockito.verify(this.sqlSession).update("updateFoo", foos.get(1));
+    Mockito.verify(this.sqlSession).update("updateFoo", foos.get(2));
+
+  }
+
+  @Test
+  void testConfigurationAssertUpdatesIsFalse() {
+
+    Mockito.when(this.sqlSession.flushStatements()).thenReturn(Collections.emptyList());
+
+    // @formatter:off
+    MyBatisBatchItemWriter<Foo> itemWriter = new MyBatisBatchItemWriterBuilder<Foo>()
+            .sqlSessionTemplate(new SqlSessionTemplate(this.sqlSessionFactory, ExecutorType.BATCH))
+            .statementId("updateFoo")
+            .assertUpdates(false)
+            .build();
+    // @formatter:on
+    itemWriter.afterPropertiesSet();
+
+    List<Foo> foos = getFoos();
+
+    itemWriter.write(foos);
+
+    Mockito.verify(this.sqlSession).update("updateFoo", foos.get(0));
+    Mockito.verify(this.sqlSession).update("updateFoo", foos.get(1));
+    Mockito.verify(this.sqlSession).update("updateFoo", foos.get(2));
+
+  }
+
+  private List<Foo> getFoos() {
+    return Arrays.asList(new Foo("foo1"), new Foo("foo2"), new Foo("foo3"));
+  }
+
+  private static class Foo {
+    private final String name;
+
+    public Foo(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return this.name;
+    }
+  }
+
+}

--- a/src/test/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilderTest.java
+++ b/src/test/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilderTest.java
@@ -1,0 +1,158 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.spring.batch.builder;
+
+import org.apache.ibatis.cursor.Cursor;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mybatis.spring.batch.MyBatisCursorItemReader;
+import org.springframework.batch.item.ExecutionContext;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for {@link MyBatisCursorItemReaderBuilder}.
+ *
+ * @since 2.0.0
+ * @author Kazuki Shimizu
+ */
+class MyBatisCursorItemReaderBuilderTest {
+
+  @Mock
+  private SqlSessionFactory sqlSessionFactory;
+
+  @Mock
+  private SqlSession sqlSession;
+
+  @Mock
+  private Cursor<Object> cursor;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    Mockito.when(this.sqlSessionFactory.openSession(ExecutorType.SIMPLE))
+        .thenReturn(this.sqlSession);
+    Mockito.when(this.cursor.iterator()).thenReturn(getFoos().iterator());
+    Mockito.when(this.sqlSession.selectCursor("selectFoo", Collections.singletonMap("id", 1)))
+        .thenReturn(this.cursor);
+  }
+
+  @Test
+  void testConfiguration() throws Exception {
+
+    // @formatter:off
+    MyBatisCursorItemReader<Foo> itemReader = new MyBatisCursorItemReaderBuilder<Foo>()
+            .sqlSessionFactory(this.sqlSessionFactory)
+            .queryId("selectFoo")
+            .parameterValues(Collections.singletonMap("id", 1))
+            .build();
+    // @formatter:on
+    itemReader.afterPropertiesSet();
+
+    ExecutionContext executionContext = new ExecutionContext();
+    itemReader.open(executionContext);
+
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo1");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo2");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo3");
+
+    itemReader.update(executionContext);
+    Assertions.assertThat(executionContext.getInt("MyBatisCursorItemReader.read.count"))
+        .isEqualTo(3);
+    Assertions.assertThat(executionContext.containsKey("MyBatisCursorItemReader.read.count.max"))
+        .isFalse();
+
+    Assertions.assertThat(itemReader.read()).isNull();
+  }
+
+  @Test
+  void testConfigurationSaveStateIsFalse() throws Exception {
+
+    // @formatter:off
+    MyBatisCursorItemReader<Foo> itemReader = new MyBatisCursorItemReaderBuilder<Foo>()
+            .sqlSessionFactory(this.sqlSessionFactory)
+            .queryId("selectFoo")
+            .parameterValues(Collections.singletonMap("id", 1))
+            .saveState(false)
+            .build();
+    // @formatter:on
+    itemReader.afterPropertiesSet();
+
+    ExecutionContext executionContext = new ExecutionContext();
+    itemReader.open(executionContext);
+
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo1");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo2");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo3");
+
+    itemReader.update(executionContext);
+    Assertions.assertThat(executionContext.isEmpty()).isTrue();
+
+  }
+
+  @Test
+  void testConfigurationMaxItemCount() throws Exception {
+
+    // @formatter:off
+    MyBatisCursorItemReader<Foo> itemReader = new MyBatisCursorItemReaderBuilder<Foo>()
+            .sqlSessionFactory(this.sqlSessionFactory)
+            .queryId("selectFoo")
+            .parameterValues(Collections.singletonMap("id", 1))
+            .maxItemCount(2)
+            .build();
+    // @formatter:on
+    itemReader.afterPropertiesSet();
+
+    ExecutionContext executionContext = new ExecutionContext();
+    itemReader.open(executionContext);
+
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo1");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo2");
+
+    itemReader.update(executionContext);
+    Assertions.assertThat(executionContext.getInt("MyBatisCursorItemReader.read.count.max"))
+        .isEqualTo(2);
+
+    Assertions.assertThat(itemReader.read()).isNull();
+  }
+
+  private List<Object> getFoos() {
+    return Arrays.asList(new Foo("foo1"), new Foo("foo2"), new Foo("foo3"));
+  }
+
+  private static class Foo {
+    private final String name;
+
+    public Foo(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return this.name;
+    }
+  }
+
+}

--- a/src/test/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilderTest.java
+++ b/src/test/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilderTest.java
@@ -1,0 +1,194 @@
+/**
+ *    Copyright 2010-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.spring.batch.builder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.springframework.batch.item.ExecutionContext;
+
+import javax.sql.DataSource;
+
+/**
+ * Tests for {@link MyBatisPagingItemReaderBuilder}.
+ *
+ * @since 2.0.0
+ * @author Kazuki Shimizu
+ */
+class MyBatisPagingItemReaderBuilderTest {
+
+  @Mock
+  private DataSource dataSource;
+
+  @Mock
+  private SqlSessionFactory sqlSessionFactory;
+
+  @Mock
+  private SqlSession sqlSession;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    Configuration configuration = new Configuration();
+    Environment environment = new Environment("unittest", new JdbcTransactionFactory(), dataSource);
+    configuration.setEnvironment(environment);
+    Mockito.when(this.sqlSessionFactory.getConfiguration()).thenReturn(configuration);
+    Mockito.when(this.sqlSessionFactory.openSession(ExecutorType.BATCH))
+        .thenReturn(this.sqlSession);
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("id", 1);
+    parameters.put("_page", 0);
+    parameters.put("_pagesize", 10);
+    parameters.put("_skiprows", 0);
+    Mockito.when(this.sqlSession.selectList("selectFoo", parameters)).thenReturn(getFoos());
+  }
+
+  @Test
+  void testConfiguration() throws Exception {
+    // @formatter:off
+    MyBatisPagingItemReader<Foo> itemReader = new MyBatisPagingItemReaderBuilder<Foo>()
+            .sqlSessionFactory(this.sqlSessionFactory)
+            .queryId("selectFoo")
+            .parameterValues(Collections.singletonMap("id", 1))
+            .build();
+    // @formatter:on
+    itemReader.afterPropertiesSet();
+
+    ExecutionContext executionContext = new ExecutionContext();
+    itemReader.open(executionContext);
+
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo1");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo2");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo3");
+
+    itemReader.update(executionContext);
+    Assertions.assertThat(executionContext.getInt("MyBatisPagingItemReader.read.count"))
+        .isEqualTo(3);
+    Assertions.assertThat(executionContext.containsKey("MyBatisPagingItemReader.read.count.max"))
+        .isFalse();
+
+    Assertions.assertThat(itemReader.read()).isNull();
+  }
+
+  @Test
+  void testConfigurationSaveStateIsFalse() throws Exception {
+    // @formatter:off
+    MyBatisPagingItemReader<Foo> itemReader = new MyBatisPagingItemReaderBuilder<Foo>()
+            .sqlSessionFactory(this.sqlSessionFactory)
+            .queryId("selectFoo")
+            .parameterValues(Collections.singletonMap("id", 1))
+            .saveState(false)
+            .build();
+    // @formatter:on
+    itemReader.afterPropertiesSet();
+
+    ExecutionContext executionContext = new ExecutionContext();
+    itemReader.open(executionContext);
+
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo1");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo2");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo3");
+
+    itemReader.update(executionContext);
+    Assertions.assertThat(executionContext.isEmpty()).isTrue();
+  }
+
+  @Test
+  void testConfigurationMaxItemCount() throws Exception {
+    // @formatter:off
+    MyBatisPagingItemReader<Foo> itemReader = new MyBatisPagingItemReaderBuilder<Foo>()
+            .sqlSessionFactory(this.sqlSessionFactory)
+            .queryId("selectFoo")
+            .parameterValues(Collections.singletonMap("id", 1))
+            .maxItemCount(2)
+            .build();
+    // @formatter:on
+    itemReader.afterPropertiesSet();
+
+    ExecutionContext executionContext = new ExecutionContext();
+    itemReader.open(executionContext);
+
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo1");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo2");
+
+    itemReader.update(executionContext);
+    Assertions.assertThat(executionContext.getInt("MyBatisPagingItemReader.read.count.max"))
+        .isEqualTo(2);
+
+    Assertions.assertThat(itemReader.read()).isNull();
+  }
+
+  @Test
+  void testConfigurationPageSize() throws Exception {
+    // @formatter:off
+    MyBatisPagingItemReader<Foo> itemReader = new MyBatisPagingItemReaderBuilder<Foo>()
+            .sqlSessionFactory(this.sqlSessionFactory)
+            .queryId("selectFoo")
+            .parameterValues(Collections.singletonMap("id", 1))
+            .pageSize(2)
+            .build();
+    // @formatter:on
+    itemReader.afterPropertiesSet();
+
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("id", 1);
+    parameters.put("_page", 0);
+    parameters.put("_pagesize", 2);
+    parameters.put("_skiprows", 0);
+    Mockito.when(this.sqlSession.selectList("selectFoo", parameters)).thenReturn(getFoos());
+
+    ExecutionContext executionContext = new ExecutionContext();
+    itemReader.open(executionContext);
+
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo1");
+    Assertions.assertThat(itemReader.read().getName()).isEqualTo("foo2");
+    Assertions.assertThat(itemReader.read()).isNull();
+  }
+
+  private List<Object> getFoos() {
+    return Arrays.asList(new Foo("foo1"), new Foo("foo2"), new Foo("foo3"));
+  }
+
+  private static class Foo {
+    private final String name;
+
+    public Foo(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return this.name;
+    }
+  }
+
+}


### PR DESCRIPTION
I will propose to add builder classes for `ItemReader` and `ItemWriter` provided by MyBatis because Spring Batch 4.0 will support builder classes.
About builder class, please see [here](https://docs.spring.io/spring-batch/4.0.x/reference/html/whatsnew.html#whatsNewBuilders)

What do you think?