### PR TITLE
Add a missing assertion in MyBatisCursorItemReaderTest.testCloseOnFailing()

### DIFF
--- a/src/test/java/org/mybatis/spring/batch/MyBatisCursorItemReaderTest.java
+++ b/src/test/java/org/mybatis/spring/batch/MyBatisCursorItemReaderTest.java
@@ -32,6 +32,8 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.ItemStreamException;
 
+import static org.junit.Assert.fail;
+
 /**
  * Tests for {@link MyBatisCursorItemReader}.
  */
@@ -69,6 +71,7 @@ class MyBatisCursorItemReaderTest {
     ExecutionContext executionContext = new ExecutionContext();
     try {
       itemReader.open(executionContext);
+      fail();
     } catch (ItemStreamException e) {
       Assertions.assertThat(e).hasMessage("Failed to initialize the reader")
           .hasCause(new RuntimeException("error."));


### PR DESCRIPTION
This PR adds a missing assertion in `MyBatisCursorItemReaderTest.testCloseOnFailing()`.