### PR TITLE
Output parse error log.

### DIFF
--- a/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
+++ b/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
@@ -482,6 +482,7 @@ public class SqlSessionFactoryBean implements FactoryBean<SqlSessionFactory>, In
         xmlConfigBuilder.parse();
         LOGGER.debug(() -> "Parsed configuration file: '" + this.configLocation + "'");
       } catch (Exception ex) {
+        LOGGER.error(() -> "Parsed error", ex);
         throw new NestedIOException("Failed to parse config resource: " + this.configLocation, ex);
       } finally {
         ErrorContext.instance().reset();


### PR DESCRIPTION
The error message here is very important.  
It usually caused by xml error or MappedStatement duplication.

 
In the spring exception catch process(the following code), the exception here is swallowed.  Therefore, there will be a death cycle without any hint.

Do not necessarily merge this request, and hope to give enough prompt information here.

At `org.springframework.beans.factory.support.FactoryBeanRegistrySupport`:

```java
@Nullable
protected Class<?> getTypeForFactoryBean(final FactoryBean<?> factoryBean) {
    try {
        if (System.getSecurityManager() != null) {
            return AccessController.doPrivileged((PrivilegedAction<Class<?>>) () ->
                    factoryBean.getObjectType(), getAccessControlContext());
        }
        else {
            return factoryBean.getObjectType();
        }
    }
    catch (Throwable ex) {
        // Thrown from the FactoryBean's getObjectType implementation.
        logger.warn("FactoryBean threw exception from getObjectType, despite the contract saying " +
                "that it should return null if the type of its object cannot be determined yet", ex);
        return null;
    }
}
```
