### PR TITLE
print error detail when xmlConfigBuilder parse error

### DIFF
--- a/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
+++ b/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
@@ -482,7 +482,9 @@ public class SqlSessionFactoryBean implements FactoryBean<SqlSessionFactory>, In
         xmlConfigBuilder.parse();
         LOGGER.debug(() -> "Parsed configuration file: '" + this.configLocation + "'");
       } catch (Exception ex) {
-        throw new NestedIOException("Failed to parse config resource: " + this.configLocation, ex);
+        throw new NestedIOException(
+            "Failed to parse config resource: " + this.configLocation + " error detail: " + ErrorContext.instance(),
+            ex);
       } finally {
         ErrorContext.instance().reset();
       }
@@ -505,7 +507,9 @@ public class SqlSessionFactoryBean implements FactoryBean<SqlSessionFactory>, In
               configuration, mapperLocation.toString(), configuration.getSqlFragments());
           xmlMapperBuilder.parse();
         } catch (Exception e) {
-          throw new NestedIOException("Failed to parse mapping resource: '" + mapperLocation + "'", e);
+          throw new NestedIOException(
+              "Failed to parse mapping resource: '" + mapperLocation + "'" + " error detail: " + ErrorContext
+                  .instance(), e);
         } finally {
           ErrorContext.instance().reset();
         }

--- a/src/test/java/org/mybatis/spring/SqlSessionFactoryBeanTest.java
+++ b/src/test/java/org/mybatis/spring/SqlSessionFactoryBeanTest.java
@@ -296,6 +296,16 @@ public final class SqlSessionFactoryBeanTest {
   }
 
   @Test
+  void testErrorMessageWhenXmlConfigBuilderParseError() throws Exception {
+    setupFactoryBean();
+
+    factoryBean.setConfigLocation(new org.springframework.core.io.ClassPathResource(
+        "org/mybatis/spring/mybatis-config-problem.xml"));
+    Throwable e = assertThrows(Exception.class, () -> factoryBean.getObject());
+    assertThat(e.getMessage()).contains("The error may exist in org/mybatis/spring/TestProblemMapper.xml");
+  }
+
+  @Test
   void testNullMapperLocations() throws Exception {
     setupFactoryBean();
     // default should also be null, but test explicitly setting to null

--- a/src/test/java/org/mybatis/spring/TestProblemMapper.xml
+++ b/src/test/java/org/mybatis/spring/TestProblemMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2010-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.mybatis.spring.TestProblemMapper">
+
+    <select id="findProblemTest">
+        SELECT *
+        FROM table_test WHERE id = #{}
+    </select>
+</mapper>

--- a/src/test/java/org/mybatis/spring/mybatis-config-problem.xml
+++ b/src/test/java/org/mybatis/spring/mybatis-config-problem.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2010-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <settings>
+        <!-- changes from the defaults for testing -->
+        <setting name="cacheEnabled" value="false" />
+        <setting name="useGeneratedKeys" value="true" />
+        <setting name="defaultExecutorType" value="REUSE" />
+        <setting name="vfsImpl" value="org.apache.ibatis.io.JBoss6VFS"/>
+    </settings>
+
+    <mappers>
+        <mapper resource="org/mybatis/spring/TestProblemMapper.xml" />
+    </mappers>
+
+</configuration>


### PR DESCRIPTION
when xmlConfigBuilder parse xml file error,the stack of the error will not identify which file it is.
I think printing error detail in threadLocal may be more friendly for developers