### PR TITLE
Relax MyBatisPagingItemReader to allow constructor instanciation

### DIFF
--- a/src/main/java/org/mybatis/spring/batch/MyBatisPagingItemReader.java
+++ b/src/main/java/org/mybatis/spring/batch/MyBatisPagingItemReader.java
@@ -93,21 +93,10 @@ public class MyBatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
   }
 
   @Override
-  protected void doOpen() throws Exception {
-    super.doOpen();
-    sqlSessionTemplate = new SqlSessionTemplate(sqlSessionFactory, ExecutorType.BATCH);
-  }
-
-  @Override
-  protected void doClose() throws Exception {
-    if (sqlSessionTemplate != null) {
-      sqlSessionTemplate.close();
-    }
-    super.doClose();
-  }
-
-  @Override
   protected void doReadPage() {
+    if (sqlSessionTemplate == null) {
+      sqlSessionTemplate = new SqlSessionTemplate(sqlSessionFactory, ExecutorType.BATCH);
+    }
     Map<String, Object> parameters = new HashMap<>();
     if (parameterValues != null) {
       parameters.putAll(parameterValues);

--- a/src/main/java/org/mybatis/spring/batch/MyBatisPagingItemReader.java
+++ b/src/main/java/org/mybatis/spring/batch/MyBatisPagingItemReader.java
@@ -18,6 +18,7 @@ package org.mybatis.spring.batch;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.batch.item.database.AbstractPagingItemReader;
 
 import java.util.HashMap;
@@ -43,7 +44,7 @@ public class MyBatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
 
   private SqlSessionFactory sqlSessionFactory;
 
-  private SqlSession sqlSession;
+  private SqlSessionTemplate sqlSessionTemplate;
 
   private Map<String, Object> parameterValues;
 
@@ -94,13 +95,13 @@ public class MyBatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
   @Override
   protected void doOpen() throws Exception {
     super.doOpen();
-    sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH);
+    sqlSessionTemplate = new SqlSessionTemplate(sqlSessionFactory, ExecutorType.BATCH);
   }
 
   @Override
   protected void doClose() throws Exception {
-    if (sqlSession != null) {
-      sqlSession.close();
+    if (sqlSessionTemplate != null) {
+      sqlSessionTemplate.close();
     }
     super.doClose();
   }
@@ -119,7 +120,7 @@ public class MyBatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
     } else {
       results.clear();
     }
-    results.addAll(sqlSession.selectList(queryId, parameters));
+    results.addAll(sqlSessionTemplate.selectList(queryId, parameters));
   }
 
   @Override


### PR DESCRIPTION
This PR is linked to the issue #323 

Basically, I used the `SqlSession` interface instead of the `SqlSessionTemplate` implementation.

I override `doOpen()` and `doClose()` to avoid initialization of the connection through `afterPropertiesSet`.

This is not a final version ready to be merged since it is missing unit tests. I just wanted to show any other solution. 