### PR TITLE
Allow to specify custom MapperFactoryBean class on xml based bean definition

### DIFF
--- a/src/main/java/org/mybatis/spring/config/MapperScannerBeanDefinitionParser.java
+++ b/src/main/java/org/mybatis/spring/config/MapperScannerBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2016 the original author or authors.
+ *    Copyright 2010-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ public class MapperScannerBeanDefinitionParser implements BeanDefinitionParser {
   private static final String ATTRIBUTE_NAME_GENERATOR = "name-generator";
   private static final String ATTRIBUTE_TEMPLATE_REF = "template-ref";
   private static final String ATTRIBUTE_FACTORY_REF = "factory-ref";
+  private static final String ATTRIBUTE_MAPPER_FACTORY_BEAN_CLASS = "mapper-factory-bean-class";
 
   /**
    * {@inheritDoc}
@@ -76,6 +77,13 @@ public class MapperScannerBeanDefinitionParser implements BeanDefinitionParser {
         Class<?> nameGeneratorClass = classLoader.loadClass(nameGeneratorClassName);
         BeanNameGenerator nameGenerator = BeanUtils.instantiateClass(nameGeneratorClass, BeanNameGenerator.class);
         scanner.setBeanNameGenerator(nameGenerator);
+      }
+      String mapperFactoryBeanClassName = element.getAttribute(ATTRIBUTE_MAPPER_FACTORY_BEAN_CLASS);
+      if (StringUtils.hasText(mapperFactoryBeanClassName)) {
+        @SuppressWarnings("unchecked")
+        Class<? extends MapperFactoryBean> mapperFactoryBeanClass =
+            (Class<? extends MapperFactoryBean>)classLoader.loadClass(mapperFactoryBeanClassName);
+        scanner.setMapperFactoryBeanClass(mapperFactoryBeanClass);
       }
     } catch (Exception ex) {
       readerContext.error(ex.getMessage(), readerContext.extractSource(element), ex.getCause());

--- a/src/main/java/org/mybatis/spring/config/mybatis-spring.xsd
+++ b/src/main/java/org/mybatis/spring/config/mybatis-spring.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2010-2018 the original author or authors.
+       Copyright 2010-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -101,6 +101,21 @@
             <tool:annotation>
               <tool:expected-type type="java.lang.Class" />
               <tool:assignable-to type="org.springframework.beans.factory.support.BeanNameGenerator" />
+            </tool:annotation>
+          </xsd:appinfo>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="mapper-factory-bean-class" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+              The fully-qualified class name of the MapperFactoryBean to return a mybatis proxy as spring bean. (Since 2.0.1)
+            ]]>
+          </xsd:documentation>
+          <xsd:appinfo>
+            <tool:annotation>
+              <tool:expected-type type="java.lang.Class" />
+              <tool:assignable-to type="org.mybatis.spring.mapper.MapperFactoryBean" />
             </tool:annotation>
           </xsd:appinfo>
         </xsd:annotation>

--- a/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
+++ b/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2018 the original author or authors.
+ *    Copyright 2010-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -107,6 +107,8 @@ public class MapperScannerConfigurer implements BeanDefinitionRegistryPostProces
   private Class<? extends Annotation> annotationClass;
 
   private Class<?> markerInterface;
+
+  private Class<? extends MapperFactoryBean> mapperFactoryBeanClass;
 
   private ApplicationContext applicationContext;
 
@@ -242,6 +244,16 @@ public class MapperScannerConfigurer implements BeanDefinitionRegistryPostProces
   }
 
   /**
+   * The class of the {@link MapperFactoryBean} to return a mybatis proxy as spring bean.
+   *
+   * @param mapperFactoryBeanClass The class of the MapperFactoryBean
+   * @since 2.0.1
+   */
+  public void setMapperFactoryBeanClass(Class<? extends MapperFactoryBean> mapperFactoryBeanClass) {
+    this.mapperFactoryBeanClass = mapperFactoryBeanClass;
+  }
+
+  /**
    * {@inheritDoc}
    */
   @Override
@@ -314,6 +326,7 @@ public class MapperScannerConfigurer implements BeanDefinitionRegistryPostProces
     scanner.setSqlSessionTemplateBeanName(this.sqlSessionTemplateBeanName);
     scanner.setResourceLoader(this.applicationContext);
     scanner.setBeanNameGenerator(this.nameGenerator);
+    scanner.setMapperFactoryBeanClass(this.mapperFactoryBeanClass);
     scanner.registerFilters();
     scanner.scan(StringUtils.tokenizeToStringArray(this.basePackage, ConfigurableApplicationContext.CONFIG_LOCATION_DELIMITERS));
   }

--- a/src/test/java/org/mybatis/spring/annotation/MapperScanTest.java
+++ b/src/test/java/org/mybatis/spring/annotation/MapperScanTest.java
@@ -166,6 +166,7 @@ class MapperScanTest {
 
   @Test
   void testCustomMapperFactoryBean() {
+    DummyMapperFactoryBean.clear();
     applicationContext.register(AppConfigWithCustomMapperFactoryBean.class);
 
     startContext();

--- a/src/test/java/org/mybatis/spring/config/NamespaceTest.java
+++ b/src/test/java/org/mybatis/spring/config/NamespaceTest.java
@@ -15,6 +15,7 @@
  */
 package org.mybatis.spring.config;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.AfterEach;
@@ -25,6 +26,7 @@ import org.mybatis.spring.mapper.AnnotatedMapper;
 import org.mybatis.spring.mapper.MapperInterface;
 import org.mybatis.spring.mapper.MapperSubinterface;
 import org.mybatis.spring.mapper.child.MapperChildInterface;
+import org.mybatis.spring.type.DummyMapperFactoryBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConstructorArgumentValues;
@@ -168,6 +170,24 @@ class NamespaceTest {
     applicationContext.getBean("mapperSubinterface");
     applicationContext.getBean("mapperChildInterface");
     applicationContext.getBean("annotatedMapper");
+  }
+
+  @Test
+  void testScanWithMapperFactoryBeanClass() {
+    DummyMapperFactoryBean.clear();
+    applicationContext = new ClassPathXmlApplicationContext(
+        new String[] { "org/mybatis/spring/config/mapper-factory-bean-class.xml" }
+        , setupSqlSessionTemplate());
+
+    startContext();
+
+    // all interfaces with methods should be loaded
+    applicationContext.getBean("mapperInterface");
+    applicationContext.getBean("mapperSubinterface");
+    applicationContext.getBean("mapperChildInterface");
+    applicationContext.getBean("annotatedMapper");
+
+    assertTrue(DummyMapperFactoryBean.getMapperCount() > 0);
   }
 
   private GenericApplicationContext setupSqlSessionTemplate() {

--- a/src/test/java/org/mybatis/spring/config/mapper-factory-bean-class.xml
+++ b/src/test/java/org/mybatis/spring/config/mapper-factory-bean-class.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2010-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:mybatis="http://mybatis.org/schema/mybatis-spring"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://mybatis.org/schema/mybatis-spring http://mybatis.org/schema/mybatis-spring.xsd">
+
+  <mybatis:scan base-package="org.mybatis.spring.mapper"
+                mapper-factory-bean-class="org.mybatis.spring.type.DummyMapperFactoryBean"/>
+</beans>

--- a/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
+++ b/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
@@ -16,6 +16,7 @@
 package org.mybatis.spring.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Properties;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.mapper.child.MapperChildInterface;
+import org.mybatis.spring.type.DummyMapperFactoryBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConstructorArgumentValues;
@@ -253,6 +255,23 @@ class MapperScannerConfigurerTest {
         .getBean("sqlSessionFactory");
     assertThat(sessionFactory.getConfiguration().getDefaultExecutorType()).isSameAs(ExecutorType.REUSE);
   }
+
+  @Test
+  void testScanWithMapperFactoryBeanClass() {
+    DummyMapperFactoryBean.clear();
+    applicationContext.getBeanDefinition("mapperScanner").getPropertyValues().add(
+        "mapperFactoryBeanClass", DummyMapperFactoryBean.class);
+
+    startContext();
+
+    applicationContext.getBean("mapperInterface");
+    applicationContext.getBean("mapperSubinterface");
+    applicationContext.getBean("mapperChildInterface");
+    applicationContext.getBean("annotatedMapper");
+
+    assertTrue(DummyMapperFactoryBean.getMapperCount() > 0);
+  }
+
 
   private void setupSqlSessionFactory(String name) {
     GenericBeanDefinition definition = new GenericBeanDefinition();

--- a/src/test/java/org/mybatis/spring/type/DummyMapperFactoryBean.java
+++ b/src/test/java/org/mybatis/spring/type/DummyMapperFactoryBean.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2010-2017 the original author or authors.
+ *    Copyright 2010-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -77,4 +77,9 @@ public class DummyMapperFactoryBean<T> extends MapperFactoryBean<T> {
   public static int getMapperCount(){
     return mapperInstanceCount.get();
   }
+
+  public static void clear() {
+    mapperInstanceCount.set(0);
+  }
+
 }


### PR DESCRIPTION
I've supported to specify a custom MapperFactoryBean on `<mybatis:scan>`(`MapperScannerBeanDefinitionParser`) and `MapperScannerConfigurer` because support `factoryBean` attribute at `@MapperScan`.

`@MapperScan` (Already supported in 2.0.0 or before) :

```java
@MapperScan(basePackages = "x.y.z.mapper", factoryBean = CustomMapperFactoryBean.class)
public class DataAccessConfiguration {
  // ...
}
```


XML namespace (Will support since 2.0.1):

```xml
<mybatis:scan base-package="x.y.z.mapper"
                mapper-factory-bean-class="x.y.z.mapper.CustomMapperFactoryBean"/>
```

`MapperScannerConfigurer` (Will support since 2.0.1):

```xml
<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
  <property name="basePackage" value="x.y.z.mapper" />
  <property name="mapperFactoryBeanClass" value="x.y.z.mapper.CustomMapperFactoryBean" />
  <!-- ... -->
</bean>

