### PR TITLE
Update dependencies (except derby)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman-bmunit</artifactId>
-      <version>4.0.5</version>
+      <version>4.0.6</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -292,9 +292,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.transaction</groupId>
-      <artifactId>javax.transaction-api</artifactId>
-      <version>1.3</version>
+      <groupId>jakarta.transaction</groupId>
+      <artifactId>jakarta.transaction-api</artifactId>
+      <version>1.3.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <spring-batch.version>4.1.1.RELEASE</spring-batch.version>
     <module.name>org.mybatis.spring</module.name>
 
-    <junit.version>5.4.1</junit.version>
+    <junit.version>5.4.2</junit.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 
     <mybatis.version>3.5.1</mybatis.version>
     <spring.version>5.1.6.RELEASE</spring.version>
-    <spring-batch.version>4.1.1.RELEASE</spring-batch.version>
+    <spring-batch.version>4.1.2.RELEASE</spring-batch.version>
     <module.name>org.mybatis.spring</module.name>
 
     <junit.version>5.4.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.11.1</version>
+      <version>3.12.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -298,9 +298,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>4.0.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.23.4</version>
+      <version>2.27.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
derby breaks the tests.  All others pass.