### PR TITLE
Introduce Spring's AliasFor declaration in MapperScan

### DIFF
--- a/src/main/java/org/mybatis/spring/annotation/MapperScan.java
+++ b/src/main/java/org/mybatis/spring/annotation/MapperScan.java
@@ -27,6 +27,7 @@ import org.mybatis.spring.mapper.MapperFactoryBean;
 import org.mybatis.spring.mapper.MapperScannerConfigurer;
 import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.AliasFor;
 
 /**
  * Use this annotation to register MyBatis mapper interfaces when using Java Config. It performs when same work as
@@ -67,7 +68,7 @@ import org.springframework.context.annotation.Import;
  *
  * @author Michael Lanyon
  * @author Eduardo Macarron
- *
+ * @author Qimiao Chen
  * @since 1.2.0
  * @see MapperScannerRegistrar
  * @see MapperFactoryBean
@@ -85,6 +86,7 @@ public @interface MapperScan {
    *
    * @return base package names
    */
+  @AliasFor("basePackages")
   String[] value() default {};
 
   /**
@@ -93,6 +95,7 @@ public @interface MapperScan {
    *
    * @return base package names for scanning mapper interface
    */
+  @AliasFor("value")
   String[] basePackages() default {};
 
   /**

--- a/src/main/java/org/mybatis/spring/annotation/MapperScannerRegistrar.java
+++ b/src/main/java/org/mybatis/spring/annotation/MapperScannerRegistrar.java
@@ -112,8 +112,6 @@ public class MapperScannerRegistrar implements ImportBeanDefinitionRegistrar, Re
     }
 
     List<String> basePackages = new ArrayList<>();
-    basePackages.addAll(
-        Arrays.stream(annoAttrs.getStringArray("value")).filter(StringUtils::hasText).collect(Collectors.toList()));
 
     basePackages.addAll(Arrays.stream(annoAttrs.getStringArray("basePackages")).filter(StringUtils::hasText)
         .collect(Collectors.toList()));


### PR DESCRIPTION
Introduce Spring's `AliasFor` declaration in `MapperScan`,  We only need to get all the attributes  through `basePackages` , without checking `value`, even if the user only fills in `value`.
Also this annotation `AliasFor` adds readability to some extent, I think this is a nice feature and hope you can consider introducing, looking forward to your reply.




