### PR TITLE
Support scoped proxy on mapper scan feature

### DIFF
--- a/src/main/java/org/mybatis/spring/annotation/MapperScan.java
+++ b/src/main/java/org/mybatis/spring/annotation/MapperScan.java
@@ -25,13 +25,14 @@ import java.lang.annotation.Target;
 
 import org.mybatis.spring.mapper.MapperFactoryBean;
 import org.mybatis.spring.mapper.MapperScannerConfigurer;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.Import;
 
 /**
  * Use this annotation to register MyBatis mapper interfaces when using Java Config. It performs when same work as
  * {@link MapperScannerConfigurer} via {@link MapperScannerRegistrar}.
- * 
+ *
  * <p>
  * Either {@link #basePackageClasses} or {@link #basePackages} (or its alias {@link #value}) may be specified to define
  * specific packages to scan. Since 2.0.4, If specific packages are not defined, scanning will occur from the package of
@@ -40,7 +41,7 @@ import org.springframework.context.annotation.Import;
  * <p>
  * Configuration example:
  * </p>
- * 
+ *
  * <pre class="code">
  * &#064;Configuration
  * &#064;MapperScan("org.mybatis.spring.sample.mapper")
@@ -165,10 +166,21 @@ public @interface MapperScan {
    * <p>
    * Default is {@code false}.
    * </p>
-   * 
+   *
    * @return set {@code true} to enable lazy initialization
    * @since 2.0.2
    */
   String lazyInitialization() default "";
+
+  /**
+   * Specifies the default scope of scanned mappers.
+   *
+   * <p>
+   * Default is {@code ""} (equiv to singleton).
+   * </p>
+   *
+   * @return the default scope
+   */
+  String defaultScope() default AbstractBeanDefinition.SCOPE_DEFAULT;
 
 }

--- a/src/main/java/org/mybatis/spring/annotation/MapperScannerRegistrar.java
+++ b/src/main/java/org/mybatis/spring/annotation/MapperScannerRegistrar.java
@@ -25,6 +25,7 @@ import org.mybatis.spring.mapper.ClassPathMapperScanner;
 import org.mybatis.spring.mapper.MapperFactoryBean;
 import org.mybatis.spring.mapper.MapperScannerConfigurer;
 import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanNameGenerator;
@@ -53,7 +54,7 @@ public class MapperScannerRegistrar implements ImportBeanDefinitionRegistrar, Re
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @deprecated Since 2.0.2, this method not used never.
    */
   @Override
@@ -130,6 +131,11 @@ public class MapperScannerRegistrar implements ImportBeanDefinitionRegistrar, Re
       builder.addPropertyValue("lazyInitialization", lazyInitialization);
     }
 
+    String defaultScope = annoAttrs.getString("defaultScope");
+    if (!AbstractBeanDefinition.SCOPE_DEFAULT.equals(defaultScope)) {
+      builder.addPropertyValue("defaultScope", defaultScope);
+    }
+
     builder.addPropertyValue("basePackage", StringUtils.collectionToCommaDelimitedString(basePackages));
 
     registry.registerBeanDefinition(beanName, builder.getBeanDefinition());
@@ -146,7 +152,7 @@ public class MapperScannerRegistrar implements ImportBeanDefinitionRegistrar, Re
 
   /**
    * A {@link MapperScannerRegistrar} for {@link MapperScans}.
-   * 
+   *
    * @since 2.0.0
    */
   static class RepeatingRegistrar extends MapperScannerRegistrar {

--- a/src/main/java/org/mybatis/spring/config/MapperScannerBeanDefinitionParser.java
+++ b/src/main/java/org/mybatis/spring/config/MapperScannerBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2010-2019 the original author or authors.
+ * Copyright 2010-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package org.mybatis.spring.config;
 
 import java.lang.annotation.Annotation;
 
-import org.mybatis.spring.mapper.MapperFactoryBean;
 import org.mybatis.spring.mapper.ClassPathMapperScanner;
+import org.mybatis.spring.mapper.MapperFactoryBean;
 import org.mybatis.spring.mapper.MapperScannerConfigurer;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -33,7 +33,7 @@ import org.w3c.dom.Element;
 
 /**
  * A {#code BeanDefinitionParser} that handles the element scan of the MyBatis. namespace
- * 
+ *
  * @author Lishu Luo
  * @author Eduardo Macarron
  *
@@ -53,10 +53,11 @@ public class MapperScannerBeanDefinitionParser extends AbstractBeanDefinitionPar
   private static final String ATTRIBUTE_FACTORY_REF = "factory-ref";
   private static final String ATTRIBUTE_MAPPER_FACTORY_BEAN_CLASS = "mapper-factory-bean-class";
   private static final String ATTRIBUTE_LAZY_INITIALIZATION = "lazy-initialization";
+  private static final String ATTRIBUTE_DEFAULT_SCOPE = "default-scope";
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @since 2.0.2
    */
   @Override
@@ -100,6 +101,7 @@ public class MapperScannerBeanDefinitionParser extends AbstractBeanDefinitionPar
     builder.addPropertyValue("sqlSessionTemplateBeanName", element.getAttribute(ATTRIBUTE_TEMPLATE_REF));
     builder.addPropertyValue("sqlSessionFactoryBeanName", element.getAttribute(ATTRIBUTE_FACTORY_REF));
     builder.addPropertyValue("lazyInitialization", element.getAttribute(ATTRIBUTE_LAZY_INITIALIZATION));
+    builder.addPropertyValue("defaultScope", element.getAttribute(ATTRIBUTE_DEFAULT_SCOPE));
     builder.addPropertyValue("basePackage", element.getAttribute(ATTRIBUTE_BASE_PACKAGE));
 
     return builder.getBeanDefinition();
@@ -107,7 +109,7 @@ public class MapperScannerBeanDefinitionParser extends AbstractBeanDefinitionPar
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @since 2.0.2
    */
   @Override

--- a/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
+++ b/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
@@ -119,6 +119,8 @@ public class MapperScannerConfigurer
 
   private BeanNameGenerator nameGenerator;
 
+  private String defaultScope;
+
   /**
    * This property lets you set the base package for your mapper interface files.
    * <p>
@@ -312,6 +314,20 @@ public class MapperScannerConfigurer
   }
 
   /**
+   * Sets the default scope of scanned mappers.
+   * <p>
+   * Default is {@code null} (equiv to singleton).
+   * </p>
+   *
+   * @param defaultScope
+   *          the default scope
+   * @since 2.0.6
+   */
+  public void setDefaultScope(String defaultScope) {
+    this.defaultScope = defaultScope;
+  }
+
+  /**
    * {@inheritDoc}
    */
   @Override
@@ -352,6 +368,9 @@ public class MapperScannerConfigurer
     if (StringUtils.hasText(lazyInitialization)) {
       scanner.setLazyInitialization(Boolean.valueOf(lazyInitialization));
     }
+    if (StringUtils.hasText(defaultScope)) {
+      scanner.setDefaultScope(defaultScope);
+    }
     scanner.registerFilters();
     scanner.scan(
         StringUtils.tokenizeToStringArray(this.basePackage, ConfigurableApplicationContext.CONFIG_LOCATION_DELIMITERS));
@@ -387,6 +406,7 @@ public class MapperScannerConfigurer
       this.sqlSessionFactoryBeanName = updatePropertyValue("sqlSessionFactoryBeanName", values);
       this.sqlSessionTemplateBeanName = updatePropertyValue("sqlSessionTemplateBeanName", values);
       this.lazyInitialization = updatePropertyValue("lazyInitialization", values);
+      this.defaultScope = updatePropertyValue("defaultScope", values);
     }
     this.basePackage = Optional.ofNullable(this.basePackage).map(getEnvironment()::resolvePlaceholders).orElse(null);
     this.sqlSessionFactoryBeanName = Optional.ofNullable(this.sqlSessionFactoryBeanName)
@@ -395,6 +415,7 @@ public class MapperScannerConfigurer
         .map(getEnvironment()::resolvePlaceholders).orElse(null);
     this.lazyInitialization = Optional.ofNullable(this.lazyInitialization).map(getEnvironment()::resolvePlaceholders)
         .orElse(null);
+    this.defaultScope = Optional.ofNullable(this.defaultScope).map(getEnvironment()::resolvePlaceholders).orElse(null);
   }
 
   private Environment getEnvironment() {

--- a/src/main/resources/org/mybatis/spring/config/mybatis-spring.xsd
+++ b/src/main/resources/org/mybatis/spring/config/mybatis-spring.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2019 the original author or authors.
+    Copyright 2010-2020 the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -135,6 +135,15 @@
           <xsd:documentation>
             <![CDATA[
               Whether enable lazy initialization of mapper bean. Set true to enable lazy initialization. (Since 2.0.2)
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="default-scope" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+              Specifies the default scope of scanned mappers. (Since 2.0.6)
             ]]>
           </xsd:documentation>
         </xsd:annotation>

--- a/src/test/java/org/mybatis/spring/annotation/mapper/ds1/Ds1Mapper.java
+++ b/src/test/java/org/mybatis/spring/annotation/mapper/ds1/Ds1Mapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2010-2019 the original author or authors.
+ * Copyright 2010-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,7 @@
 package org.mybatis.spring.annotation.mapper.ds1;
 
 public interface Ds1Mapper {
+  default String test() {
+    return "ds1";
+  }
 }

--- a/src/test/java/org/mybatis/spring/annotation/mapper/ds2/Ds2Mapper.java
+++ b/src/test/java/org/mybatis/spring/annotation/mapper/ds2/Ds2Mapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2010-2019 the original author or authors.
+ * Copyright 2010-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,5 +15,11 @@
  */
 package org.mybatis.spring.annotation.mapper.ds2;
 
+import org.springframework.context.annotation.Scope;
+
+@Scope
 public interface Ds2Mapper {
+  default String test() {
+    return "ds2";
+  }
 }

--- a/src/test/java/org/mybatis/spring/config/default-scope.properties
+++ b/src/test/java/org/mybatis/spring/config/default-scope.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2010-2019 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+mybatis.default-scope=thread

--- a/src/test/java/org/mybatis/spring/config/default-scope.xml
+++ b/src/test/java/org/mybatis/spring/config/default-scope.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2010-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:mybatis="http://mybatis.org/schema/mybatis-spring"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://mybatis.org/schema/mybatis-spring http://mybatis.org/schema/mybatis-spring.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+  <context:property-placeholder location="classpath:/org/mybatis/spring/config/default-scope.properties"/>
+
+  <bean class="org.springframework.beans.factory.config.CustomScopeConfigurer">
+    <property name="scopes">
+      <map>
+        <entry key="thread">
+          <bean class="org.springframework.context.support.SimpleThreadScope"/>
+        </entry>
+      </map>
+    </property>
+  </bean>
+
+  <mybatis:scan base-package="org.mybatis.spring.mapper" default-scope="${mybatis.default-scope:}" />
+</beans>

--- a/src/test/java/org/mybatis/spring/mapper/ScopedProxyMapper.java
+++ b/src/test/java/org/mybatis/spring/mapper/ScopedProxyMapper.java
@@ -15,16 +15,14 @@
  */
 package org.mybatis.spring.mapper;
 
-import org.springframework.stereotype.Component;
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 
-// annotated interface for MapperScannerPostProcessor tests
-// ensures annotated classes are loaded
-@Component
-public interface AnnotatedMapper {
-  void method();
-
+@Mapper
+@Scope(scopeName = "thread", proxyMode = ScopedProxyMode.TARGET_CLASS)
+public interface ScopedProxyMapper {
   default String test() {
-    return Thread.currentThread().getName();
+    return "test";
   }
-
 }


### PR DESCRIPTION
Fixes gh-476

By this change, the develop become can specified scope of mapper using mapper scan feature option and scope annotation(`@Scope`, `@RefreshScope`, etc ...).
The `defaultScope` apply to the mapper bean(`MapperFactoryBean`) when scope of scanned bean definition is `singleton` (default scope) and create a scoped proxy bean for scanned mapper when final scope is not `singleton`.

## Usage option on mapper scan feature

The developer can specify the scope of mapper bean that not specified scope annotation using option of mapper scan feature. 

### Using `@MapperScan`

```java
@Cpnfiguration
@MapperScan(defaultScope = "refresh")
class MyBatisConfig {
  // ...
}
```

### Using `MapperScannerConfigurer`

```java
@Bean
MapperScannerConfigurer mapperScannerConfigurer() {
  MapperScannerConfigurer configurer = new MapperScannerConfigurer();
  configurer.setDefaultScope("refresh");
  // ...
  return  configurer;
}
```

### Using XML Namespace(`<mybatis:mapper-scan/>`)

```xml
<mybatis:scan base-package="org.mybatis.spring.mapper" default-scope="refresh" />
```

## Using scope annotation

The developer can specify the scope per mapper using scope annotation.

```java
// equiv to @Scope(scopeName = "refresh", proxyMode = ScopedProxyMode.TARGET_CLASS)
@RefreshScope
@Mapper 
public interface MyMapper {
  // ...
}
```

