### PR TITLE
Set attribute that helps MockitoPostProcessor replace a MyBatis mapper bean with a mock

### DIFF
--- a/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
+++ b/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
@@ -57,6 +57,9 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ClassPathMapperScanner.class);
 
+  // Copy of FactoryBean#OBJECT_TYPE_ATTRIBUTE which was added in Spring 5.2
+  static final String FACTORY_BEAN_OBJECT_TYPE = "factoryBeanObjectType";
+
   private boolean addToConfig = true;
 
   private boolean lazyInitialization;
@@ -233,6 +236,10 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
       definition.setBeanClass(this.mapperFactoryBeanClass);
 
       definition.getPropertyValues().add("addToConfig", this.addToConfig);
+
+      // Attribute for MockitoPostProcessor
+      // https://github.com/mybatis/spring-boot-starter/issues/475
+      definition.setAttribute(FACTORY_BEAN_OBJECT_TYPE, beanClassName);
 
       boolean explicitFactoryUsed = false;
       if (StringUtils.hasText(this.sqlSessionFactoryBeanName)) {

--- a/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
+++ b/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
@@ -385,6 +385,14 @@ class MapperScannerConfigurerTest {
     assertTrue(DummyMapperFactoryBean.getMapperCount() > 0);
   }
 
+  @Test
+  void testMapperBeanAttribute() {
+    startContext();
+
+    assertThat(applicationContext.getBeanDefinition("annotatedMapper").getAttribute(ClassPathMapperScanner.FACTORY_BEAN_OBJECT_TYPE))
+        .isEqualTo(AnnotatedMapper.class.getName());
+  }
+
   private void setupSqlSessionFactory(String name) {
     GenericBeanDefinition definition = new GenericBeanDefinition();
     definition.setBeanClass(SqlSessionFactoryBean.class);


### PR DESCRIPTION
https://github.com/mybatis/spring-boot-starter/issues/475
https://github.com/spring-projects/spring-boot/commit/f4985abf3cd299f0842d9f474942c418f177eb13

I found the solution in a similar bug report.
https://github.com/spring-projects/spring-boot/issues/21379

As the constant was added in Spring Beans 5.2, I had to declare a package private constant.