### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+cache:
+  directories:
+  - $HOME/.m2
+
 jdk:
   - openjdk16
   - openjdk15


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.