### PR TITLE
SqlSessionDaoSupport create dozens of SqlSessionTemplate  instances meaningless

### DIFF
--- a/src/main/java/org/mybatis/spring/support/SqlSessionDaoSupport.java
+++ b/src/main/java/org/mybatis/spring/support/SqlSessionDaoSupport.java
@@ -47,7 +47,7 @@ public abstract class SqlSessionDaoSupport extends DaoSupport {
    *          a template of SqlSession
    * @see #setSqlSessionFactory
    */
-  public void setSqlSessionTemplate(SqlSessionTemplate sqlSessionTemplate) {
+  public void setSqlSessionATemplate(SqlSessionTemplate sqlSessionTemplate) {
     this.sqlSessionTemplate = sqlSessionTemplate;
   }
 


### PR DESCRIPTION
According to  the spring #populateBean method  injecting properties' order， reorder the #setSqlSessionTemplate and  #setSqlSessionFactory methods postion.
Currently, #setSqlSessionFactory method be invoked before #setSqlSessionTemplate ,it will create SqlSessionTemplate meaningless,  because  the #setSqlSessionTemplate will override the instance the #setSqlSessionFactory method created .This #createSqlSessionTemplate method  will  be invoked dozens of times meaningless.  It will create dozens  of SqlSessionTemplate  instances.