### PR TITLE
method which in Object.class should be filtered in SqlSessionInterceptor

### DIFF
--- a/src/main/java/org/mybatis/spring/SqlSessionTemplate.java
+++ b/src/main/java/org/mybatis/spring/SqlSessionTemplate.java
@@ -421,6 +421,10 @@ public class SqlSessionTemplate implements SqlSession, DisposableBean {
   private class SqlSessionInterceptor implements InvocationHandler {
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      if (Object.class.equals(method.getDeclaringClass())) {
+        return method.invoke(this, args);
+      }
+
       SqlSession sqlSession = getSqlSession(SqlSessionTemplate.this.sqlSessionFactory,
           SqlSessionTemplate.this.executorType, SqlSessionTemplate.this.exceptionTranslator);
       try {


### PR DESCRIPTION
method which in Object.class should be filtered in SqlSessionInterceptor, Otherwise it will cause debug trouble, every breakpoint debug in idea will invoke toString, then the invoke method in SqlSessionIntercetor also be invoked, cause the SqlSessionHolder will init, may be cause IllegalStateException

Although it can run normally without filtering, from the perspective of code rigor and the framework user's perspective, I personally think that it is necessary to do the corresponding processing 