### PR TITLE
Modify standard CI setting for ignoring on compatibility-check-spring6 branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,11 @@
 
 name: Java CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'compatibility-check-spring6'
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -16,7 +16,11 @@
 
 name: Coveralls
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'compatibility-check-spring6'
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/support.yaml
+++ b/.github/workflows/support.yaml
@@ -16,7 +16,11 @@
 
 name: Spring/Spring Batch Support
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'compatibility-check-spring6'
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
See gh-634

At first, I modify standard CI setting for ignoring on `compatibility-check-spring6` branch. At next, I add branch to check a compatibility with Spring 6 and Spring Batch 5. At last, I add new GitHub workflow to check a compatibility with Spring 6 and Spring Batch 5.