### PR TITLE
local output timestamp for Reproducible Builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <module.name>org.mybatis.spring</module.name>
 
     <junit.version>5.8.2</junit.version>
-
+    <project.build.outputTimestamp>1645112687</project.build.outputTimestamp>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
instead of inheriting timestamp from parent, which represents the timestamp when the parent was released, having a local timestamp will be more accurate to the actual release