### PR TITLE
[fix]When spring has more than one ApplicationContext, it will throw BeanCreationNotAllowedException.

### DIFF
--- a/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
+++ b/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
@@ -87,7 +87,7 @@ import org.springframework.util.ClassUtils;
  * @see #setDataSource
  */
 public class SqlSessionFactoryBean
-    implements FactoryBean<SqlSessionFactory>, InitializingBean, ApplicationListener<ApplicationEvent> {
+    implements FactoryBean<SqlSessionFactory>, InitializingBean, ApplicationListener<ContextRefreshedEvent> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SqlSessionFactoryBean.class);
 
@@ -656,8 +656,8 @@ public class SqlSessionFactoryBean
    * {@inheritDoc}
    */
   @Override
-  public void onApplicationEvent(ApplicationEvent event) {
-    if (failFast && event instanceof ContextRefreshedEvent) {
+  public void onApplicationEvent(ContextRefreshedEvent event) {
+    if (failFast) {
       // fail-fast -> check all statements are completed
       this.sqlSessionFactory.getConfiguration().getMappedStatementNames();
     }


### PR DESCRIPTION
When spring has more than one ApplicationContext, it will issue multiple ContextClosedEvent when the application is closed, at this time if the SqlSessionFactoryBean has been destroyed before the second event, it will throw BeanCreationNotAllowedException.