### PR TITLE
Add parameter supplier support to spring batch readers

### DIFF
--- a/src/main/java/org/mybatis/spring/batch/MyBatisCursorItemReader.java
+++ b/src/main/java/org/mybatis/spring/batch/MyBatisCursorItemReader.java
@@ -21,6 +21,7 @@ import static org.springframework.util.ClassUtils.getShortName;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.apache.ibatis.cursor.Cursor;
@@ -42,7 +43,7 @@ public class MyBatisCursorItemReader<T> extends AbstractItemCountingItemStreamIt
   private SqlSession sqlSession;
 
   private Map<String, Object> parameterValues;
-  private Supplier<Map<String, Object>> parameterSupplier;
+  private Supplier<Map<String, Object>> parameterValuesSupplier;
 
   private Cursor<T> cursor;
   private Iterator<T> cursorIterator;
@@ -67,10 +68,7 @@ public class MyBatisCursorItemReader<T> extends AbstractItemCountingItemStreamIt
       parameters.putAll(parameterValues);
     }
 
-    Map<String, Object> dynamicParameters;
-    if (parameterSupplier != null && (dynamicParameters = parameterSupplier.get()) != null) {
-      parameters.putAll(dynamicParameters);
-    }
+    Optional.ofNullable(parameterValuesSupplier).map(Supplier::get).ifPresent(parameters::putAll);
 
     sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE);
     cursor = sqlSession.selectCursor(queryId, parameters);
@@ -132,10 +130,12 @@ public class MyBatisCursorItemReader<T> extends AbstractItemCountingItemStreamIt
   /**
    * The parameter supplier used to get parameter values for the query execution.
    *
-   * @param parameterSupplier
+   * @param parameterValuesSupplier
    *          the supplier used to get values keyed by the parameter named used in the query string.
+   *
+   * @since 2.1.0
    */
-  public void setParameterSupplier(Supplier<Map<String, Object>> parameterSupplier) {
-    this.parameterSupplier = parameterSupplier;
+  public void setParameterValuesSupplier(Supplier<Map<String, Object>> parameterValuesSupplier) {
+    this.parameterValuesSupplier = parameterValuesSupplier;
   }
 }

--- a/src/main/java/org/mybatis/spring/batch/MyBatisCursorItemReader.java
+++ b/src/main/java/org/mybatis/spring/batch/MyBatisCursorItemReader.java
@@ -21,6 +21,7 @@ import static org.springframework.util.ClassUtils.getShortName;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.session.ExecutorType;
@@ -41,6 +42,7 @@ public class MyBatisCursorItemReader<T> extends AbstractItemCountingItemStreamIt
   private SqlSession sqlSession;
 
   private Map<String, Object> parameterValues;
+  private Supplier<Map<String, Object>> parameterSupplier;
 
   private Cursor<T> cursor;
   private Iterator<T> cursorIterator;
@@ -63,6 +65,11 @@ public class MyBatisCursorItemReader<T> extends AbstractItemCountingItemStreamIt
     Map<String, Object> parameters = new HashMap<>();
     if (parameterValues != null) {
       parameters.putAll(parameterValues);
+    }
+
+    Map<String, Object> dynamicParameters;
+    if (parameterSupplier != null && (dynamicParameters = parameterSupplier.get()) != null) {
+      parameters.putAll(dynamicParameters);
     }
 
     sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE);
@@ -120,5 +127,15 @@ public class MyBatisCursorItemReader<T> extends AbstractItemCountingItemStreamIt
    */
   public void setParameterValues(Map<String, Object> parameterValues) {
     this.parameterValues = parameterValues;
+  }
+
+  /**
+   * The parameter supplier used to get parameter values for the query execution.
+   *
+   * @param parameterSupplier
+   *          the supplier used to get values keyed by the parameter named used in the query string.
+   */
+  public void setParameterSupplier(Supplier<Map<String, Object>> parameterSupplier) {
+    this.parameterSupplier = parameterSupplier;
   }
 }

--- a/src/main/java/org/mybatis/spring/batch/MyBatisPagingItemReader.java
+++ b/src/main/java/org/mybatis/spring/batch/MyBatisPagingItemReader.java
@@ -20,6 +20,7 @@ import static org.springframework.util.ClassUtils.getShortName;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 
@@ -48,7 +49,7 @@ public class MyBatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
 
   private Map<String, Object> parameterValues;
 
-  private Supplier<Map<String, Object>> parameterSupplier;
+  private Supplier<Map<String, Object>> parameterValuesSupplier;
 
   public MyBatisPagingItemReader() {
     setName(getShortName(MyBatisPagingItemReader.class));
@@ -87,11 +88,13 @@ public class MyBatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
   /**
    * The parameter supplier used to get parameter values for the query execution.
    *
-   * @param parameterSupplier
+   * @param parameterValuesSupplier
    *          the supplier used to get values keyed by the parameter named used in the query string.
+   *
+   * @since 2.1.0
    */
-  public void setParameterSupplier(Supplier<Map<String, Object>> parameterSupplier) {
-    this.parameterSupplier = parameterSupplier;
+  public void setParameterValuesSupplier(Supplier<Map<String, Object>> parameterValuesSupplier) {
+    this.parameterValuesSupplier = parameterValuesSupplier;
   }
 
   /**
@@ -115,10 +118,7 @@ public class MyBatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
     if (parameterValues != null) {
       parameters.putAll(parameterValues);
     }
-    Map<String, Object> dynamicParameters;
-    if (parameterSupplier != null && (dynamicParameters = parameterSupplier.get()) != null) {
-      parameters.putAll(dynamicParameters);
-    }
+    Optional.ofNullable(parameterValuesSupplier).map(Supplier::get).ifPresent(parameters::putAll);
     parameters.put("_page", getPage());
     parameters.put("_pagesize", getPageSize());
     parameters.put("_skiprows", getPage() * getPageSize());

--- a/src/main/java/org/mybatis/spring/batch/MyBatisPagingItemReader.java
+++ b/src/main/java/org/mybatis/spring/batch/MyBatisPagingItemReader.java
@@ -21,6 +21,7 @@ import static org.springframework.util.ClassUtils.getShortName;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
 
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
@@ -46,6 +47,8 @@ public class MyBatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
   private SqlSessionTemplate sqlSessionTemplate;
 
   private Map<String, Object> parameterValues;
+
+  private Supplier<Map<String, Object>> parameterSupplier;
 
   public MyBatisPagingItemReader() {
     setName(getShortName(MyBatisPagingItemReader.class));
@@ -82,6 +85,16 @@ public class MyBatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
   }
 
   /**
+   * The parameter supplier used to get parameter values for the query execution.
+   *
+   * @param parameterSupplier
+   *          the supplier used to get values keyed by the parameter named used in the query string.
+   */
+  public void setParameterSupplier(Supplier<Map<String, Object>> parameterSupplier) {
+    this.parameterSupplier = parameterSupplier;
+  }
+
+  /**
    * Check mandatory properties.
    *
    * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
@@ -101,6 +114,10 @@ public class MyBatisPagingItemReader<T> extends AbstractPagingItemReader<T> {
     Map<String, Object> parameters = new HashMap<>();
     if (parameterValues != null) {
       parameters.putAll(parameterValues);
+    }
+    Map<String, Object> dynamicParameters;
+    if (parameterSupplier != null && (dynamicParameters = parameterSupplier.get()) != null) {
+      parameters.putAll(dynamicParameters);
     }
     parameters.put("_page", getPage());
     parameters.put("_pagesize", getPageSize());

--- a/src/main/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilder.java
+++ b/src/main/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilder.java
@@ -36,7 +36,7 @@ public class MyBatisCursorItemReaderBuilder<T> {
   private SqlSessionFactory sqlSessionFactory;
   private String queryId;
   private Map<String, Object> parameterValues;
-  private Supplier<Map<String, Object>> parameterSupplier;
+  private Supplier<Map<String, Object>> parameterValuesSupplier;
   private Boolean saveState;
   private Integer maxItemCount;
 
@@ -88,15 +88,18 @@ public class MyBatisCursorItemReaderBuilder<T> {
   /**
    * Set the parameter supplier to be used to get parameters for the query execution.
    *
-   * @param parameterSupplier
+   * @param parameterValuesSupplier
    *          the parameter supplier to be used to get parameters for the query execution
    *
    * @return this instance for method chaining
    *
-   * @see MyBatisCursorItemReader#setParameterSupplier(Supplier)
+   * @see MyBatisCursorItemReader#setParameterValuesSupplier(Supplier)
+   *
+   * @since 2.1.0
    */
-  public MyBatisCursorItemReaderBuilder<T> parameterSupplier(Supplier<Map<String, Object>> parameterSupplier) {
-    this.parameterSupplier = parameterSupplier;
+  public MyBatisCursorItemReaderBuilder<T> parameterValuesSupplier(
+      Supplier<Map<String, Object>> parameterValuesSupplier) {
+    this.parameterValuesSupplier = parameterValuesSupplier;
     return this;
   }
 
@@ -141,7 +144,7 @@ public class MyBatisCursorItemReaderBuilder<T> {
     reader.setSqlSessionFactory(this.sqlSessionFactory);
     reader.setQueryId(this.queryId);
     reader.setParameterValues(this.parameterValues);
-    reader.setParameterSupplier(this.parameterSupplier);
+    reader.setParameterValuesSupplier(this.parameterValuesSupplier);
     Optional.ofNullable(this.saveState).ifPresent(reader::setSaveState);
     Optional.ofNullable(this.maxItemCount).ifPresent(reader::setMaxItemCount);
     return reader;

--- a/src/main/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilder.java
+++ b/src/main/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilder.java
@@ -17,6 +17,7 @@ package org.mybatis.spring.batch.builder;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.batch.MyBatisCursorItemReader;
@@ -35,6 +36,7 @@ public class MyBatisCursorItemReaderBuilder<T> {
   private SqlSessionFactory sqlSessionFactory;
   private String queryId;
   private Map<String, Object> parameterValues;
+  private Supplier<Map<String, Object>> parameterSupplier;
   private Boolean saveState;
   private Integer maxItemCount;
 
@@ -84,6 +86,21 @@ public class MyBatisCursorItemReaderBuilder<T> {
   }
 
   /**
+   * Set the parameter supplier to be used to get parameters for the query execution.
+   *
+   * @param parameterSupplier
+   *          the parameter supplier to be used to get parameters for the query execution
+   *
+   * @return this instance for method chaining
+   *
+   * @see MyBatisCursorItemReader#setParameterSupplier(Supplier)
+   */
+  public MyBatisCursorItemReaderBuilder<T> parameterSupplier(Supplier<Map<String, Object>> parameterSupplier) {
+    this.parameterSupplier = parameterSupplier;
+    return this;
+  }
+
+  /**
    * Configure if the state of the {@link org.springframework.batch.item.ItemStreamSupport} should be persisted within
    * the {@link org.springframework.batch.item.ExecutionContext} for restart purposes.
    *
@@ -124,6 +141,7 @@ public class MyBatisCursorItemReaderBuilder<T> {
     reader.setSqlSessionFactory(this.sqlSessionFactory);
     reader.setQueryId(this.queryId);
     reader.setParameterValues(this.parameterValues);
+    reader.setParameterSupplier(this.parameterSupplier);
     Optional.ofNullable(this.saveState).ifPresent(reader::setSaveState);
     Optional.ofNullable(this.maxItemCount).ifPresent(reader::setMaxItemCount);
     return reader;

--- a/src/main/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilder.java
+++ b/src/main/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilder.java
@@ -17,6 +17,7 @@ package org.mybatis.spring.batch.builder;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.batch.MyBatisPagingItemReader;
@@ -35,6 +36,7 @@ public class MyBatisPagingItemReaderBuilder<T> {
   private SqlSessionFactory sqlSessionFactory;
   private String queryId;
   private Map<String, Object> parameterValues;
+  private Supplier<Map<String, Object>> parameterSupplier;
   private Integer pageSize;
   private Boolean saveState;
   private Integer maxItemCount;
@@ -81,6 +83,21 @@ public class MyBatisPagingItemReaderBuilder<T> {
    */
   public MyBatisPagingItemReaderBuilder<T> parameterValues(Map<String, Object> parameterValues) {
     this.parameterValues = parameterValues;
+    return this;
+  }
+
+  /**
+   * Set the parameter supplier to be used to get parameters for the query execution.
+   *
+   * @param parameterSupplier
+   *          the parameter supplier to be used to get parameters for the query execution
+   *
+   * @return this instance for method chaining
+   *
+   * @see MyBatisPagingItemReader#setParameterSupplier(Supplier)
+   */
+  public MyBatisPagingItemReaderBuilder<T> parameterSupplier(Supplier<Map<String, Object>> parameterSupplier) {
+    this.parameterSupplier = parameterSupplier;
     return this;
   }
 
@@ -140,6 +157,7 @@ public class MyBatisPagingItemReaderBuilder<T> {
     reader.setSqlSessionFactory(this.sqlSessionFactory);
     reader.setQueryId(this.queryId);
     reader.setParameterValues(this.parameterValues);
+    reader.setParameterSupplier(this.parameterSupplier);
     Optional.ofNullable(this.pageSize).ifPresent(reader::setPageSize);
     Optional.ofNullable(this.saveState).ifPresent(reader::setSaveState);
     Optional.ofNullable(this.maxItemCount).ifPresent(reader::setMaxItemCount);

--- a/src/main/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilder.java
+++ b/src/main/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilder.java
@@ -36,7 +36,7 @@ public class MyBatisPagingItemReaderBuilder<T> {
   private SqlSessionFactory sqlSessionFactory;
   private String queryId;
   private Map<String, Object> parameterValues;
-  private Supplier<Map<String, Object>> parameterSupplier;
+  private Supplier<Map<String, Object>> parameterValuesSupplier;
   private Integer pageSize;
   private Boolean saveState;
   private Integer maxItemCount;
@@ -89,15 +89,18 @@ public class MyBatisPagingItemReaderBuilder<T> {
   /**
    * Set the parameter supplier to be used to get parameters for the query execution.
    *
-   * @param parameterSupplier
+   * @param parameterValuesSupplier
    *          the parameter supplier to be used to get parameters for the query execution
    *
    * @return this instance for method chaining
    *
-   * @see MyBatisPagingItemReader#setParameterSupplier(Supplier)
+   * @see MyBatisPagingItemReader#setParameterValuesSupplier(Supplier)
+   *
+   * @since 2.1.0
    */
-  public MyBatisPagingItemReaderBuilder<T> parameterSupplier(Supplier<Map<String, Object>> parameterSupplier) {
-    this.parameterSupplier = parameterSupplier;
+  public MyBatisPagingItemReaderBuilder<T> parameterValuesSupplier(
+      Supplier<Map<String, Object>> parameterValuesSupplier) {
+    this.parameterValuesSupplier = parameterValuesSupplier;
     return this;
   }
 
@@ -157,7 +160,7 @@ public class MyBatisPagingItemReaderBuilder<T> {
     reader.setSqlSessionFactory(this.sqlSessionFactory);
     reader.setQueryId(this.queryId);
     reader.setParameterValues(this.parameterValues);
-    reader.setParameterSupplier(this.parameterSupplier);
+    reader.setParameterValuesSupplier(this.parameterValuesSupplier);
     Optional.ofNullable(this.pageSize).ifPresent(reader::setPageSize);
     Optional.ofNullable(this.saveState).ifPresent(reader::setSaveState);
     Optional.ofNullable(this.maxItemCount).ifPresent(reader::setMaxItemCount);

--- a/src/test/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilderTest.java
+++ b/src/test/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilderTest.java
@@ -72,7 +72,7 @@ class MyBatisCursorItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
-            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
+            .parameterValuesSupplier(() -> Collections.singletonMap("name", "Doe"))
             .build();
     // @formatter:on
     itemReader.afterPropertiesSet();
@@ -99,7 +99,7 @@ class MyBatisCursorItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
-            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
+            .parameterValuesSupplier(() -> Collections.singletonMap("name", "Doe"))
             .saveState(false)
             .build();
     // @formatter:on
@@ -125,7 +125,7 @@ class MyBatisCursorItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
-            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
+            .parameterValuesSupplier(() -> Collections.singletonMap("name", "Doe"))
             .maxItemCount(2)
             .build();
     // @formatter:on

--- a/src/test/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilderTest.java
+++ b/src/test/java/org/mybatis/spring/batch/builder/MyBatisCursorItemReaderBuilderTest.java
@@ -17,7 +17,9 @@ package org.mybatis.spring.batch.builder;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.session.ExecutorType;
@@ -56,7 +58,10 @@ class MyBatisCursorItemReaderBuilderTest {
 
     Mockito.when(this.sqlSessionFactory.openSession(ExecutorType.SIMPLE)).thenReturn(this.sqlSession);
     Mockito.when(this.cursor.iterator()).thenReturn(getFoos().iterator());
-    Mockito.when(this.sqlSession.selectCursor("selectFoo", Collections.singletonMap("id", 1))).thenReturn(this.cursor);
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("id", 1);
+    parameters.put("name", "Doe");
+    Mockito.when(this.sqlSession.selectCursor("selectFoo", parameters)).thenReturn(this.cursor);
   }
 
   @Test
@@ -67,6 +72,7 @@ class MyBatisCursorItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
+            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
             .build();
     // @formatter:on
     itemReader.afterPropertiesSet();
@@ -93,6 +99,7 @@ class MyBatisCursorItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
+            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
             .saveState(false)
             .build();
     // @formatter:on
@@ -118,6 +125,7 @@ class MyBatisCursorItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
+            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
             .maxItemCount(2)
             .build();
     // @formatter:on

--- a/src/test/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilderTest.java
+++ b/src/test/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilderTest.java
@@ -81,7 +81,7 @@ class MyBatisPagingItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
-            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
+            .parameterValuesSupplier(() -> Collections.singletonMap("name", "Doe"))
             .build();
     // @formatter:on
     itemReader.afterPropertiesSet();
@@ -107,7 +107,7 @@ class MyBatisPagingItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
-            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
+            .parameterValuesSupplier(() -> Collections.singletonMap("name", "Doe"))
             .saveState(false)
             .build();
     // @formatter:on
@@ -131,7 +131,7 @@ class MyBatisPagingItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
-            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
+            .parameterValuesSupplier(() -> Collections.singletonMap("name", "Doe"))
             .maxItemCount(2)
             .build();
     // @formatter:on
@@ -156,7 +156,7 @@ class MyBatisPagingItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
-            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
+            .parameterValuesSupplier(() -> Collections.singletonMap("name", "Doe"))
             .pageSize(2)
             .build();
     // @formatter:on

--- a/src/test/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilderTest.java
+++ b/src/test/java/org/mybatis/spring/batch/builder/MyBatisPagingItemReaderBuilderTest.java
@@ -67,6 +67,7 @@ class MyBatisPagingItemReaderBuilderTest {
     Mockito.when(this.sqlSessionFactory.openSession(ExecutorType.BATCH)).thenReturn(this.sqlSession);
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("id", 1);
+    parameters.put("name", "Doe");
     parameters.put("_page", 0);
     parameters.put("_pagesize", 10);
     parameters.put("_skiprows", 0);
@@ -80,6 +81,7 @@ class MyBatisPagingItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
+            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
             .build();
     // @formatter:on
     itemReader.afterPropertiesSet();
@@ -105,6 +107,7 @@ class MyBatisPagingItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
+            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
             .saveState(false)
             .build();
     // @formatter:on
@@ -128,6 +131,7 @@ class MyBatisPagingItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
+            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
             .maxItemCount(2)
             .build();
     // @formatter:on
@@ -152,6 +156,7 @@ class MyBatisPagingItemReaderBuilderTest {
             .sqlSessionFactory(this.sqlSessionFactory)
             .queryId("selectFoo")
             .parameterValues(Collections.singletonMap("id", 1))
+            .parameterSupplier(() -> Collections.singletonMap("name", "Doe"))
             .pageSize(2)
             .build();
     // @formatter:on
@@ -160,6 +165,7 @@ class MyBatisPagingItemReaderBuilderTest {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("id", 1);
     parameters.put("_page", 0);
+    parameters.put("name", "Doe");
     parameters.put("_pagesize", 2);
     parameters.put("_skiprows", 0);
     Mockito.when(this.sqlSession.selectList("selectFoo", parameters)).thenReturn(getFoos());


### PR DESCRIPTION
In my use case of  ```MyBatisCursorItemReader```  like below, I have to specify query parameters **before** the Spring Container is initialized, which works well at first.
```java
@Configuration
public class SomeStepConfig {
    ...

    @Bean
    public Step someStep() {
        return stepBuilderFactory.get("someStep")
                .<SomeIn, SomeOut>chunk(1000)
                .reader(reader())
                .processor(processor())
                .writer(writer())
                .build();
    }
    MyBatisCursorItemReader reader() {
        return new MyBatisCursorItemReaderBuilder<SomeIn>()
                .sqlSessionFactory(this.sqlSessionFactory)
                .queryId("selectSelectId")
                .parameterValues(Collections.singletonMap("key", "value"))
                .build();
    }

    ...
}
```
After a few iterations, the query parameters needs to be determined by a preceding step, which is **after** Spring Container initialized, and I didn't come up with any elegant solution. So I made a copy of  source code of ```MyBatisCursorItemReaderBuilder``` & ```MyBatisCursorItemReader``` in my project, and then made some changes to them as shown in this PR.

The client code becomes
```java
@Configuration
public class SomeStepConfig {
    ...

    MyBatisCursorItemReader reader() {
        return new MyBatisCursorItemReaderBuilder<SomeIn>()
                .sqlSessionFactory(this.sqlSessionFactory)
                .queryId("selectSelectId")
                .parameterSupplier(() -> parameterMapFromLocalOrRemote())
                .build();
    }
    private Map<String, Object> parameterMapFromLocalOrRemote() {
        ...
    }

    ...
}
```
It works great so far, except that copying whole source of ```MyBatisCursorItemReaderBuilder``` & ```MyBatisCursorItemReader``` is not elegant enough. I considered subclassing, but the private fields makes it rather difficult.

Considering this is a very useful feature, at least for me, the changes are very small and simple, I was wondering if I could make a contribute. So I added the same feature to ```MyBatisPagingItemReaderBuilder``` & ```MyBatisPagingItemReader``` and made some changes to unit tests for the feature. Then there is this PR.

Thanks for you time for anyone review or read this PR.