### PR TITLE
[pom] Fix java release version: must be 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,10 @@
     <gcu.product>Spring</gcu.product>
     <osgi.import>org.springframework.batch.*;resolution:=optional,*</osgi.import>
     <osgi.dynamicImport>*</osgi.dynamicImport>
+
+    <!-- Maven compiler options -->
     <java.version>17</java.version>
+    <java.release.version>17</java.release.version>
 
     <mybatis.version>3.5.11</mybatis.version>
     <spring.version>6.0.2</spring.version>


### PR DESCRIPTION
was mixing meta data with source/target at 17 but release at 8, surprising it worked to compile...