### PR TITLE
fix: change the event type that SqlSessionFactory is listening to

### DIFF
--- a/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
+++ b/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
@@ -54,7 +54,6 @@ import org.mybatis.logging.LoggerFactory;
 import org.mybatis.spring.transaction.SpringManagedTransactionFactory;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -87,7 +86,7 @@ import org.springframework.util.ClassUtils;
  * @see #setDataSource
  */
 public class SqlSessionFactoryBean
-    implements FactoryBean<SqlSessionFactory>, InitializingBean, ApplicationListener<ApplicationEvent> {
+    implements FactoryBean<SqlSessionFactory>, InitializingBean, ApplicationListener<ContextRefreshedEvent> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SqlSessionFactoryBean.class);
 
@@ -658,8 +657,8 @@ public class SqlSessionFactoryBean
    * {@inheritDoc}
    */
   @Override
-  public void onApplicationEvent(ApplicationEvent event) {
-    if (failFast && event instanceof ContextRefreshedEvent) {
+  public void onApplicationEvent(ContextRefreshedEvent event) {
+    if (failFast) {
       // fail-fast -> check all statements are completed
       this.sqlSessionFactory.getConfiguration().getMappedStatementNames();
     }


### PR DESCRIPTION
fixes #796 
### This is why I need to change it.
1. From the implementation of SqlSessionFactory, I think that it does not need to listen to all ApplicationEvents, and only needs to listen to ContextRefreshedEvent.
2. When there are multiple ApplicationContexts in Spring, ContextClosedEvent may be broadcasted multiple times. For example, FeignContext, since SqlSessionFactory listens to all ApplicationEvents, if the application is closed, when SqlSessionFactoryBean is destroyed first, and FeignContext is destroyed later, ContextClosedEvent will be broadcasted. When Spring tries to get the listener, BeanCreationNotAllowedException is thrown because SqlSessionFactoryBean's singleton bean has been destroyed and it indicates that singletons are currently being destroyed (singletonsCurrentlyInDestruction=true).
Although Spring considers this only a warning, I think that SqlSessionFactoryBean does not need to listen to all ApplicationEvents, and this warning should not appear in this case.