### PR TITLE
Support spring.aot.enabled=true

### DIFF
--- a/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
+++ b/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 the original author or authors.
+ * Copyright 2010-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.mybatis.logging.LoggerFactory;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.aop.scope.ScopedProxyFactoryBean;
 import org.springframework.aop.scope.ScopedProxyUtils;
+import org.springframework.aot.AotDetector;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
@@ -87,7 +88,7 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
 
   public ClassPathMapperScanner(BeanDefinitionRegistry registry) {
     super(registry, false);
-    setIncludeAnnotationConfig(!NativeDetector.inNativeImage());
+    setIncludeAnnotationConfig(!AotDetector.useGeneratedArtifacts());
     setPrintWarnLogIfNotFoundMappers(!NativeDetector.inNativeImage());
   }
 


### PR DESCRIPTION
Fixes gh-780

Fix to use the AotDetector#useGeneratedArtifacts() instead of NativeDetector.inNativeImage() for set the includeAnnotationConfig to false on the ClassPathMapperScanner