### PR TITLE
Use the TransactionSynchronization instead of TransactionSynchronizationAdapter on 2.1.x

### DIFF
--- a/src/main/java/org/mybatis/spring/SqlSessionUtils.java
+++ b/src/main/java/org/mybatis/spring/SqlSessionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 the original author or authors.
+ * Copyright 2010-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.dao.TransientDataAccessResourceException;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.jdbc.datasource.DataSourceUtils;
-import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
@@ -225,7 +225,7 @@ public final class SqlSessionUtils {
    * {@code SqlSession}. It assumes that {@code Connection} life cycle will be managed by
    * {@code DataSourceTransactionManager} or {@code JtaTransactionManager}
    */
-  private static final class SqlSessionSynchronization extends TransactionSynchronizationAdapter {
+  private static final class SqlSessionSynchronization implements TransactionSynchronization {
 
     private final SqlSessionHolder holder;
 


### PR DESCRIPTION
TransactionSynchronizationAdapter is deprecated already

(cherry picked from commit 894b7a39ef0505c34fcb57cdbcb91d534b74d330)

Related: gh-819