### PR TITLE
Corrected to set bean class instead of bean class name to factoryBeanObjectType of BeanDefinition attribute

### DIFF
--- a/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
+++ b/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
@@ -262,8 +262,12 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
       // but, the actual class of the bean is MapperFactoryBean
       definition.getConstructorArgumentValues().addGenericArgumentValue(beanClassName); // issue #59
       try {
+        Class<?> beanClass = Resources.classForName(beanClassName);
+        // Attribute for MockitoPostProcessor
+        // https://github.com/mybatis/spring-boot-starter/issues/475
+        definition.setAttribute(FACTORY_BEAN_OBJECT_TYPE, beanClass);
         // for spring-native
-        definition.getPropertyValues().add("mapperInterface", Resources.classForName(beanClassName));
+        definition.getPropertyValues().add("mapperInterface", beanClass);
       } catch (ClassNotFoundException ignore) {
         // ignore
       }
@@ -271,10 +275,6 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
       definition.setBeanClass(this.mapperFactoryBeanClass);
 
       definition.getPropertyValues().add("addToConfig", this.addToConfig);
-
-      // Attribute for MockitoPostProcessor
-      // https://github.com/mybatis/spring-boot-starter/issues/475
-      definition.setAttribute(FACTORY_BEAN_OBJECT_TYPE, beanClassName);
 
       boolean explicitFactoryUsed = false;
       if (StringUtils.hasText(this.sqlSessionFactoryBeanName)) {

--- a/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
+++ b/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 the original author or authors.
+ * Copyright 2010-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -399,7 +399,7 @@ class MapperScannerConfigurerTest {
     startContext();
 
     assertThat(applicationContext.getBeanDefinition("annotatedMapper")
-        .getAttribute(ClassPathMapperScanner.FACTORY_BEAN_OBJECT_TYPE)).isEqualTo(AnnotatedMapper.class.getName());
+        .getAttribute(ClassPathMapperScanner.FACTORY_BEAN_OBJECT_TYPE)).isEqualTo(AnnotatedMapper.class);
   }
 
   private void setupSqlSessionFactory(String name) {


### PR DESCRIPTION
Fixes gh-855

### Changes

We used the `factoryBeanObjectType` of BeanDefinition attribute for supporting `@MockBean`/`@SpyBean` provided Spring Boot via gh-494. But since Spring Framework 6.1, this attribute cannot pass value of String type. Thefore we change to pass the bean type instead of bean class name. This change valid on latest version of Spring Boot 3.0.x and 3.1.x and 3.2.x.
 
### Related Links

* gh-494
* spring-projects/spring-framework#29799
* mybatis/spring-boot-starter#894
* mybatis/spring-boot-starter#899 (backporting for Spring Boot 2.x)
* https://github.com/kazuki43zoo/mybatis-spring-boot-dev-compatibility-checker/actions/runs/6619221515 (Verify on Spring Boot 3.0, 3.1 and 3.2)