### PR TITLE
Add environment to ClassPathMapperScanner to get properties from PropertySources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
     <derby.version>10.17.1.0</derby.version>
     <mybatis.version>3.5.16</mybatis.version>
     <spring.version>6.1.6</spring.version>
+    <spring-boot.version>3.2.5</spring-boot.version>
     <spring-batch.version>5.1.1</spring-batch.version>
     <module.name>org.mybatis.spring</module.name>
 
@@ -216,6 +217,13 @@
           <artifactId>junit</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>${spring-boot.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
+++ b/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2023 the original author or authors.
+ * Copyright 2010-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.annotation.ClassPathBeanDefinitionScanner;
 import org.springframework.core.NativeDetector;
+import org.springframework.core.env.Environment;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.core.type.filter.AssignableTypeFilter;
 import org.springframework.util.StringUtils;
@@ -86,6 +87,16 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
 
   private String defaultScope;
 
+  public ClassPathMapperScanner(BeanDefinitionRegistry registry, Environment environment) {
+    super(registry, false, environment);
+    setIncludeAnnotationConfig(!AotDetector.useGeneratedArtifacts());
+    setPrintWarnLogIfNotFoundMappers(!NativeDetector.inNativeImage());
+  }
+
+  /**
+   * @deprecated Please use the {@link #ClassPathMapperScanner(BeanDefinitionRegistry, Environment)}.
+   */
+  @Deprecated(since = "3.0.4", forRemoval = true)
   public ClassPathMapperScanner(BeanDefinitionRegistry registry) {
     super(registry, false);
     setIncludeAnnotationConfig(!AotDetector.useGeneratedArtifacts());

--- a/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
+++ b/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 the original author or authors.
+ * Copyright 2010-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -360,7 +360,7 @@ public class MapperScannerConfigurer
       processPropertyPlaceHolders();
     }
 
-    ClassPathMapperScanner scanner = new ClassPathMapperScanner(registry);
+    ClassPathMapperScanner scanner = new ClassPathMapperScanner(registry, getEnvironment());
     scanner.setAddToConfig(this.addToConfig);
     scanner.setAnnotationClass(this.annotationClass);
     scanner.setMarkerInterface(this.markerInterface);

--- a/src/test/java/org/mybatis/spring/mapper/AnnotatedMapperOnPropertyCondition.java
+++ b/src/test/java/org/mybatis/spring/mapper/AnnotatedMapperOnPropertyCondition.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mybatis.spring.mapper;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+// annotated interface for MapperScannerPostProcessor tests
+// ensures annotated classes are loaded on property condition
+@Component
+@ConditionalOnProperty(prefix = "mapper", value = "condition", havingValue = "true")
+public interface AnnotatedMapperOnPropertyCondition {
+  void method();
+}

--- a/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
+++ b/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2023 the original author or authors.
+ * Copyright 2010-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,8 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.context.support.SimpleThreadScope;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.mock.env.MockPropertySource;
 import org.springframework.stereotype.Component;
 
 class MapperScannerConfigurerTest {
@@ -400,6 +402,18 @@ class MapperScannerConfigurerTest {
 
     assertThat(applicationContext.getBeanDefinition("annotatedMapper")
         .getAttribute(ClassPathMapperScanner.FACTORY_BEAN_OBJECT_TYPE)).isEqualTo(AnnotatedMapper.class);
+  }
+
+  @Test
+  void testMapperBeanOnConditionalProperties() {
+    MutablePropertySources propertySources = applicationContext.getEnvironment().getPropertySources();
+    propertySources.addLast(new MockPropertySource().withProperty("mapper.condition", "true"));
+
+    startContext();
+
+    assertThat(applicationContext.getBeanDefinition("annotatedMapperOnPropertyCondition")
+        .getAttribute(ClassPathMapperScanner.FACTORY_BEAN_OBJECT_TYPE))
+            .isEqualTo(AnnotatedMapperOnPropertyCondition.class);
   }
 
   private void setupSqlSessionFactory(String name) {


### PR DESCRIPTION
In current implementation, the `Environment` is not added to `ClassPathMapperScanner`. So the scanner can not get any property from the application environment when registering bean defination.

```java
@Mapper
@ConditionalOnProperty(prefix = "mapper", value = "condition", havingValue = "true")
public interface AnnotatedMapperOnPropertyCondition {
  void method();
}
```