### PR TITLE
Fix MapperFactoryBean constructor argument for AOT

### DIFF
--- a/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
+++ b/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -285,9 +286,13 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
 
       // the mapper interface is the original class of the bean
       // but, the actual class of the bean is MapperFactoryBean
-      definition.getConstructorArgumentValues().addGenericArgumentValue(beanClassName); // issue #59
+      var constructorArgument = new ConstructorArgumentValues.ValueHolder(beanClassName); // issue #59
+      definition.getConstructorArgumentValues().addGenericArgumentValue(constructorArgument);
       try {
         Class<?> beanClass = Resources.classForName(beanClassName);
+        if (shouldUseClassConstructorArgument(this.mapperFactoryBeanClass)) {
+          constructorArgument.setValue(beanClass);
+        }
         // Attribute for MockitoPostProcessor
         // https://github.com/mybatis/spring-boot-starter/issues/475
         definition.setAttribute(FACTORY_BEAN_OBJECT_TYPE, beanClass);
@@ -357,6 +362,18 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
   @Override
   protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
     return beanDefinition.getMetadata().isInterface() && beanDefinition.getMetadata().isIndependent();
+  }
+
+  private boolean shouldUseClassConstructorArgument(Class<? extends MapperFactoryBean> mapperFactoryBeanClass) {
+    return hasSingleArgumentConstructorAccepting(mapperFactoryBeanClass, Class.class)
+        && !hasSingleArgumentConstructorAccepting(mapperFactoryBeanClass, String.class);
+  }
+
+  private boolean hasSingleArgumentConstructorAccepting(Class<? extends MapperFactoryBean> mapperFactoryBeanClass,
+      Class<?> argumentType) {
+    return Arrays.stream(mapperFactoryBeanClass.getDeclaredConstructors())
+        .anyMatch(constructor -> constructor.getParameterCount() == 1
+            && constructor.getParameterTypes()[0].isAssignableFrom(argumentType));
   }
 
   @Override

--- a/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
+++ b/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
@@ -112,14 +112,19 @@ class MapperScannerConfigurerTest {
         .hasSize(1);
     assertThat(applicationContext.getBeanDefinition("mapperInterface").getPropertyValues().get("mapperInterface"))
         .isEqualTo(MapperInterface.class);
+    assertMapperInterfaceConstructorArgument("mapperInterface", MapperInterface.class);
     assertThat(applicationContext.getBeanDefinition("mapperSubinterface").getPropertyValues().get("mapperInterface"))
         .isEqualTo(MapperSubinterface.class);
+    assertMapperInterfaceConstructorArgument("mapperSubinterface", MapperSubinterface.class);
     assertThat(applicationContext.getBeanDefinition("mapperChildInterface").getPropertyValues().get("mapperInterface"))
         .isEqualTo(MapperChildInterface.class);
+    assertMapperInterfaceConstructorArgument("mapperChildInterface", MapperChildInterface.class);
     assertThat(applicationContext.getBeanDefinition("annotatedMapper").getPropertyValues().get("mapperInterface"))
         .isEqualTo(AnnotatedMapper.class);
+    assertMapperInterfaceConstructorArgument("annotatedMapper", AnnotatedMapper.class);
     assertThat(applicationContext.getBeanDefinition("scopedTarget.scopedProxyMapper").getPropertyValues()
         .get("mapperInterface")).isEqualTo(ScopedProxyMapper.class);
+    assertMapperInterfaceConstructorArgument("scopedTarget.scopedProxyMapper", ScopedProxyMapper.class);
   }
 
   @Test
@@ -392,6 +397,31 @@ class MapperScannerConfigurerTest {
     applicationContext.getBean("annotatedMapper");
 
     assertTrue(DummyMapperFactoryBean.getMapperCount() > 0);
+    assertMapperInterfaceConstructorArgument("mapperInterface", MapperInterface.class);
+  }
+
+  @Test
+  void testScanWithStringConstructorMapperFactoryBeanClass() {
+    applicationContext.getBeanDefinition("mapperScanner").getPropertyValues().add("mapperFactoryBeanClass",
+        StringConstructorMapperFactoryBean.class);
+
+    startContext();
+
+    applicationContext.getBean("mapperInterface");
+
+    assertMapperInterfaceConstructorArgument("mapperInterface", MapperInterface.class.getName());
+  }
+
+  @Test
+  void testScanWithStringAndClassConstructorMapperFactoryBeanClass() {
+    applicationContext.getBeanDefinition("mapperScanner").getPropertyValues().add("mapperFactoryBeanClass",
+        StringAndClassConstructorMapperFactoryBean.class);
+
+    startContext();
+
+    applicationContext.getBean("mapperInterface");
+
+    assertMapperInterfaceConstructorArgument("mapperInterface", MapperInterface.class.getName());
   }
 
   @Test
@@ -430,11 +460,47 @@ class MapperScannerConfigurerTest {
     }
   }
 
+  private void assertMapperInterfaceConstructorArgument(String beanName, Class<?> mapperInterface) {
+    var constructorArguments = applicationContext.getBeanDefinition(beanName).getConstructorArgumentValues()
+        .getGenericArgumentValues();
+    assertThat(constructorArguments).hasSize(1);
+    assertThat(constructorArguments.get(0).getValue()).isEqualTo(mapperInterface);
+  }
+
+  private void assertMapperInterfaceConstructorArgument(String beanName, String mapperInterface) {
+    var constructorArguments = applicationContext.getBeanDefinition(beanName).getConstructorArgumentValues()
+        .getGenericArgumentValues();
+    assertThat(constructorArguments).hasSize(1);
+    assertThat(constructorArguments.get(0).getValue()).isEqualTo(mapperInterface);
+  }
+
   public static class BeanNameGenerator implements org.springframework.beans.factory.support.BeanNameGenerator {
 
     @Override
     public String generateBeanName(BeanDefinition beanDefinition, BeanDefinitionRegistry definitionRegistry) {
       return beanDefinition.getBeanClassName();
+    }
+
+  }
+
+  public static class StringConstructorMapperFactoryBean<T> extends MapperFactoryBean<T> {
+
+    @SuppressWarnings("unchecked")
+    public StringConstructorMapperFactoryBean(String mapperInterfaceName) throws ClassNotFoundException {
+      setMapperInterface((Class<T>) Class.forName(mapperInterfaceName));
+    }
+
+  }
+
+  public static class StringAndClassConstructorMapperFactoryBean<T> extends MapperFactoryBean<T> {
+
+    @SuppressWarnings("unchecked")
+    public StringAndClassConstructorMapperFactoryBean(String mapperInterfaceName) throws ClassNotFoundException {
+      setMapperInterface((Class<T>) Class.forName(mapperInterfaceName));
+    }
+
+    public StringAndClassConstructorMapperFactoryBean(Class<T> mapperInterface) {
+      super(mapperInterface);
     }
 
   }


### PR DESCRIPTION
This PR fixes an AOT/native runtime failure where `MapperFactoryBean` tries to resolve `Class<?>` as an autowired dependency.

`ClassPathMapperScanner` currently registers the mapper interface constructor argument as a class name `String`. This works in the regular JVM path because Spring can convert the value to the `Class<?>` constructor argument required by `MapperFactoryBean`.

In the AOT/native path, the generated bean supplier uses the `MapperFactoryBean(Class<?>)` constructor, but the bean definition still contains the mapper interface constructor argument as a `String`. The generated supplier does not appear to apply the same `String` to `Class<?>` conversion, so native runtime fails with:

```text
No qualifying bean of type 'java.lang.Class<?>' available
```

This change uses the resolved mapper interface `Class<?>` as the constructor argument only when the configured `MapperFactoryBean` has a single-argument constructor that can accept `Class<?>` and does not have a single-argument constructor that can accept `String`.

This preserves the existing `String` constructor argument behavior for custom `MapperFactoryBean` implementations that support `String`-compatible constructors.

Regression tests were added for the default `MapperFactoryBean`, a custom factory with a `String` constructor, and a custom factory with both `String` and `Class<?>` constructors.

The same constructor argument registration path also exists on `master`, so this fix may need to be forward-ported if maintainers prefer to keep the branches aligned.

Tested with:

```bash
./mvnw -Dtest=MapperScannerConfigurerTest -Dformatter.skip=true -Dwhitespace.skip=true -Dlicense.skip=true -Djacoco.skip=true -Drewrite.skip=true test
```

Also verified with a native reproduction project:

https://github.com/DragonFSKY/mybatis-3675-repro

Refs #929.
Refs mybatis/mybatis-3#3675.
