### PR TITLE
Skip mapper scanning in AOT generated runtime

### DIFF
--- a/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
+++ b/src/main/java/org/mybatis/spring/mapper/MapperScannerConfigurer.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.aot.AotDetector;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.PropertyValues;
 import org.springframework.beans.factory.BeanNameAware;
@@ -382,6 +383,10 @@ public class MapperScannerConfigurer
   public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) {
     if (this.processPropertyPlaceHolders) {
       processPropertyPlaceHolders();
+    }
+
+    if (AotDetector.useGeneratedArtifacts()) {
+      return;
     }
 
     var scanner = new ClassPathMapperScanner(registry, getEnvironment());

--- a/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
+++ b/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
@@ -36,15 +36,24 @@ import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.mapper.child.MapperChildInterface;
 import org.mybatis.spring.type.DummyMapperFactoryBean;
+import org.springframework.aot.AotDetector;
+import org.springframework.aot.generate.ClassNameGenerator;
+import org.springframework.aot.generate.DefaultGenerationContext;
+import org.springframework.aot.generate.GeneratedFiles;
+import org.springframework.aot.generate.InMemoryGeneratedFiles;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConstructorArgumentValues;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.aot.ApplicationContextAotGenerator;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.context.support.SimpleThreadScope;
+import org.springframework.core.SpringProperties;
+import org.springframework.javapoet.ClassName;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.mock.env.MockPropertySource;
 import org.springframework.stereotype.Component;
 
@@ -412,6 +421,49 @@ class MapperScannerConfigurerTest {
     assertThat(applicationContext.getBeanDefinition("annotatedMapperOnPropertyCondition")
         .getAttribute(ClassPathMapperScanner.FACTORY_BEAN_OBJECT_TYPE))
             .isEqualTo(AnnotatedMapperOnPropertyCondition.class);
+  }
+
+  @Test
+  void testMapperScannerConfigurerRegisteredInAotGeneratedRuntime() throws Exception {
+    var dataSourceDefinition = new GenericBeanDefinition();
+    dataSourceDefinition.setBeanClass(DriverManagerDataSource.class);
+    applicationContext.registerBeanDefinition("dataSource", dataSourceDefinition);
+    applicationContext.getBeanDefinition("sqlSessionFactory").getPropertyValues().add("dataSource",
+        new RuntimeBeanReference("dataSource"));
+
+    var generatedFiles = new InMemoryGeneratedFiles();
+    var generationContext = new DefaultGenerationContext(
+        new ClassNameGenerator(ClassName.get("org.mybatis.spring.mapper", "MapperScannerConfigurerAotTests")),
+        generatedFiles);
+
+    new ApplicationContextAotGenerator().processAheadOfTime(applicationContext, generationContext);
+    generationContext.writeGeneratedContent();
+
+    var source = String.join("\n", generatedFiles.getGeneratedFiles(GeneratedFiles.Kind.SOURCE).keySet());
+    assertThat(source).contains("MapperScannerConfigurer__BeanDefinitions.java");
+    assertThat(source).contains("MapperFactoryBean__BeanDefinitions.java");
+  }
+
+  @Test
+  void testSkipMapperScanWithAotGeneratedArtifacts() {
+    var definition = new GenericBeanDefinition();
+    definition.setBeanClass(MapperFactoryBean.class);
+    definition.getConstructorArgumentValues().addGenericArgumentValue(MapperInterface.class);
+    definition.getPropertyValues().add("sqlSessionFactory", new RuntimeBeanReference("sqlSessionFactory"));
+    applicationContext.registerBeanDefinition("mapperInterface", definition);
+
+    var aotEnabled = SpringProperties.getProperty(AotDetector.AOT_ENABLED);
+    SpringProperties.setFlag(AotDetector.AOT_ENABLED);
+    try {
+      startContext();
+    } finally {
+      SpringProperties.setProperty(AotDetector.AOT_ENABLED, aotEnabled);
+    }
+
+    assertThat(applicationContext.getBean("mapperScanner")).isInstanceOf(MapperScannerConfigurer.class);
+    assertThat(applicationContext.getBeanDefinition("mapperInterface").getBeanClassName())
+        .isEqualTo("org.mybatis.spring.mapper.MapperFactoryBean");
+    assertBeanNotLoaded("mapperSubinterface");
   }
 
   private void setupSqlSessionFactory(String name) {


### PR DESCRIPTION
This PR addresses the duplicate mapper scanning part of #929.

When an application runs with Spring AOT generated artifacts, mapper bean definitions have already been generated during AOT processing. However, the generated runtime still registers the MapperScannerConfigurer bean. If it scans again at runtime, it may attempt to register the same mapper bean definition and fail with ConflictingBeanDefinitionException.

This change keeps MapperScannerConfigurer registered/generated for compatibility, but skips mapper scanning when AotDetector.useGeneratedArtifacts() is true. Placeholder processing is still performed before the guard, and the regular non-AOT scanning path is unchanged.

This is complementary to #1235, which fixes the generated MapperFactoryBean constructor argument. Both changes are needed for the sample application from #929 to start successfully with AOT generated artifacts.

Tested with:

- git diff --check
- ./mvnw -Dlicense.skip=true -Drewrite.skip=true -Dformatter.skip=true -Dimpsort.skip=true -Dwhitespace.skip=true test