### PR TITLE
Fix MapperFactoryBean constructor argument for AOT

### DIFF
--- a/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
+++ b/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.beans.factory.config.ConstructorArgumentValues;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -348,9 +349,13 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
 
       // the mapper interface is the original class of the bean
       // but, the actual class of the bean is MapperFactoryBean
-      definition.getConstructorArgumentValues().addGenericArgumentValue(beanClassName); // issue #59
+      var constructorArgument = new ConstructorArgumentValues.ValueHolder(beanClassName); // issue #59
+      definition.getConstructorArgumentValues().addGenericArgumentValue(constructorArgument);
       try {
         Class<?> beanClass = Resources.classForName(beanClassName);
+        if (shouldUseClassConstructorArgument(this.mapperFactoryBeanClass)) {
+          constructorArgument.setValue(beanClass);
+        }
         // Attribute for MockitoPostProcessor
         // https://github.com/mybatis/spring-boot-starter/issues/475
         definition.setAttribute(FACTORY_BEAN_OBJECT_TYPE, beanClass);
@@ -420,6 +425,18 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
   @Override
   protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
     return beanDefinition.getMetadata().isInterface() && beanDefinition.getMetadata().isIndependent();
+  }
+
+  private boolean shouldUseClassConstructorArgument(Class<? extends MapperFactoryBean> mapperFactoryBeanClass) {
+    return hasSingleArgumentConstructorAccepting(mapperFactoryBeanClass, Class.class)
+        && !hasSingleArgumentConstructorAccepting(mapperFactoryBeanClass, String.class);
+  }
+
+  private boolean hasSingleArgumentConstructorAccepting(Class<? extends MapperFactoryBean> mapperFactoryBeanClass,
+      Class<?> argumentType) {
+    return Arrays.stream(mapperFactoryBeanClass.getDeclaredConstructors())
+        .anyMatch(constructor -> constructor.getParameterCount() == 1
+            && constructor.getParameterTypes()[0].isAssignableFrom(argumentType));
   }
 
   @Override

--- a/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
+++ b/src/test/java/org/mybatis/spring/mapper/MapperScannerConfigurerTest.java
@@ -112,14 +112,19 @@ class MapperScannerConfigurerTest {
         .hasSize(1);
     assertThat(applicationContext.getBeanDefinition("mapperInterface").getPropertyValues().get("mapperInterface"))
         .isEqualTo(MapperInterface.class);
+    assertMapperInterfaceConstructorArgument("mapperInterface", MapperInterface.class);
     assertThat(applicationContext.getBeanDefinition("mapperSubinterface").getPropertyValues().get("mapperInterface"))
         .isEqualTo(MapperSubinterface.class);
+    assertMapperInterfaceConstructorArgument("mapperSubinterface", MapperSubinterface.class);
     assertThat(applicationContext.getBeanDefinition("mapperChildInterface").getPropertyValues().get("mapperInterface"))
         .isEqualTo(MapperChildInterface.class);
+    assertMapperInterfaceConstructorArgument("mapperChildInterface", MapperChildInterface.class);
     assertThat(applicationContext.getBeanDefinition("annotatedMapper").getPropertyValues().get("mapperInterface"))
         .isEqualTo(AnnotatedMapper.class);
+    assertMapperInterfaceConstructorArgument("annotatedMapper", AnnotatedMapper.class);
     assertThat(applicationContext.getBeanDefinition("scopedTarget.scopedProxyMapper").getPropertyValues()
         .get("mapperInterface")).isEqualTo(ScopedProxyMapper.class);
+    assertMapperInterfaceConstructorArgument("scopedTarget.scopedProxyMapper", ScopedProxyMapper.class);
   }
 
   @Test
@@ -392,6 +397,31 @@ class MapperScannerConfigurerTest {
     applicationContext.getBean("annotatedMapper");
 
     assertTrue(DummyMapperFactoryBean.getMapperCount() > 0);
+    assertMapperInterfaceConstructorArgument("mapperInterface", MapperInterface.class);
+  }
+
+  @Test
+  void testScanWithStringConstructorMapperFactoryBeanClass() {
+    applicationContext.getBeanDefinition("mapperScanner").getPropertyValues().add("mapperFactoryBeanClass",
+        StringConstructorMapperFactoryBean.class);
+
+    startContext();
+
+    applicationContext.getBean("mapperInterface");
+
+    assertMapperInterfaceConstructorArgument("mapperInterface", MapperInterface.class.getName());
+  }
+
+  @Test
+  void testScanWithStringAndClassConstructorMapperFactoryBeanClass() {
+    applicationContext.getBeanDefinition("mapperScanner").getPropertyValues().add("mapperFactoryBeanClass",
+        StringAndClassConstructorMapperFactoryBean.class);
+
+    startContext();
+
+    applicationContext.getBean("mapperInterface");
+
+    assertMapperInterfaceConstructorArgument("mapperInterface", MapperInterface.class.getName());
   }
 
   @Test
@@ -430,11 +460,47 @@ class MapperScannerConfigurerTest {
     }
   }
 
+  private void assertMapperInterfaceConstructorArgument(String beanName, Class<?> mapperInterface) {
+    var constructorArguments = applicationContext.getBeanDefinition(beanName).getConstructorArgumentValues()
+        .getGenericArgumentValues();
+    assertThat(constructorArguments).hasSize(1);
+    assertThat(constructorArguments.get(0).getValue()).isEqualTo(mapperInterface);
+  }
+
+  private void assertMapperInterfaceConstructorArgument(String beanName, String mapperInterface) {
+    var constructorArguments = applicationContext.getBeanDefinition(beanName).getConstructorArgumentValues()
+        .getGenericArgumentValues();
+    assertThat(constructorArguments).hasSize(1);
+    assertThat(constructorArguments.get(0).getValue()).isEqualTo(mapperInterface);
+  }
+
   public static class BeanNameGenerator implements org.springframework.beans.factory.support.BeanNameGenerator {
 
     @Override
     public String generateBeanName(BeanDefinition beanDefinition, BeanDefinitionRegistry definitionRegistry) {
       return beanDefinition.getBeanClassName();
+    }
+
+  }
+
+  public static class StringConstructorMapperFactoryBean<T> extends MapperFactoryBean<T> {
+
+    @SuppressWarnings("unchecked")
+    public StringConstructorMapperFactoryBean(String mapperInterfaceName) throws ClassNotFoundException {
+      setMapperInterface((Class<T>) Class.forName(mapperInterfaceName));
+    }
+
+  }
+
+  public static class StringAndClassConstructorMapperFactoryBean<T> extends MapperFactoryBean<T> {
+
+    @SuppressWarnings("unchecked")
+    public StringAndClassConstructorMapperFactoryBean(String mapperInterfaceName) throws ClassNotFoundException {
+      setMapperInterface((Class<T>) Class.forName(mapperInterfaceName));
+    }
+
+    public StringAndClassConstructorMapperFactoryBean(Class<T> mapperInterface) {
+      super(mapperInterface);
     }
 
   }


### PR DESCRIPTION
## Summary
- Forward-port the #1235 fix from `3.0.x` to `master`.
- Use the resolved mapper interface `Class` as the constructor argument when the configured `MapperFactoryBean` only exposes a Class-based constructor.
- Preserve the existing String constructor argument for custom `MapperFactoryBean` implementations that accept String constructors.

## Verification
- `./mvnw -Dlicense.skip=true -Dformatter.skip=true -Dimpsort.skip=true -Dwhitespace.skip=true -Drewrite.skip=true -Dtest=MapperScannerConfigurerTest test`