### PR TITLE
Apply double-checked locking in MyBatisExceptionTranslator

### DIFF
--- a/src/main/java/org/mybatis/spring/MyBatisExceptionTranslator.java
+++ b/src/main/java/org/mybatis/spring/MyBatisExceptionTranslator.java
@@ -41,8 +41,8 @@ import org.springframework.transaction.TransactionException;
 public class MyBatisExceptionTranslator implements PersistenceExceptionTranslator {
 
   private final Supplier<SQLExceptionTranslator> exceptionTranslatorSupplier;
-  private SQLExceptionTranslator exceptionTranslator;
-  private ReentrantLock lock = new ReentrantLock();
+  private volatile SQLExceptionTranslator exceptionTranslator;
+  private final ReentrantLock lock = new ReentrantLock();
 
   /**
    * Creates a new {@code PersistenceExceptionTranslator} instance with {@code SQLErrorCodeSQLExceptionTranslator}.
@@ -104,9 +104,13 @@ public class MyBatisExceptionTranslator implements PersistenceExceptionTranslato
   }
 
   /**
-   * Initializes the internal translator reference.
+   * Initializes the internal translator reference. Uses double-checked locking so that, once the translator is created,
+   * subsequent calls take a fast path without acquiring the lock.
    */
   private void initExceptionTranslator() {
+    if (this.exceptionTranslator != null) {
+      return;
+    }
     lock.lock();
     try {
       if (this.exceptionTranslator == null) {


### PR DESCRIPTION
## Summary

`MyBatisExceptionTranslator.initExceptionTranslator()` is invoked on every
exception translation (see line 92 in master). It uses a `ReentrantLock`
to make the lazy initialization of the internal `SQLExceptionTranslator`
thread-safe, but it acquires the lock on **every** call — including the
overwhelmingly common case where the translator was already initialized.

For applications doing many concurrent JDBC operations, this is unnecessary
lock contention on the hot exception-handling path. Once the translator is
created, the lock is no longer needed.

This change applies a standard double-checked locking pattern so the lock
is only taken during the (one-time) initialization.

## Changes

- `exceptionTranslator` field: declared `volatile` so the unlocked
  fast-path read sees a properly-published value (safe DCL since JDK 5).
- `lock` field: declared `final` (previously mutable, which other lock
  fields in similar Spring/MyBatis code are not).
- `initExceptionTranslator()`: short-circuits and returns immediately when
  `exceptionTranslator != null`, avoiding the lock acquire/release on the
  steady-state path. The locked region still performs a re-check, so the
  initialization remains thread-safe with at-most-once semantics.

```java
private void initExceptionTranslator() {
  if (this.exceptionTranslator != null) {
    return;
  }
  lock.lock();
  try {
    if (this.exceptionTranslator == null) {
      this.exceptionTranslator = exceptionTranslatorSupplier.get();
    }
  } finally {
    lock.unlock();
  }
}
```

## Background

This `ReentrantLock` was introduced in #1039 (resolving #1022) as part of
replacing `synchronized` to make `MyBatisExceptionTranslator` virtual-thread
friendly. That change preserved the original behaviour of always entering
the synchronized region, but with `ReentrantLock` the same fast-path
optimization that classic DCL uses is straightforward to add.

## Verification

- `./mvnw verify` — BUILD SUCCESS, 222 tests, 0 failures, 15 skipped
  (same as baseline).
- Existing `MyBatisExceptionTranslatorTest` (5 tests) covers eager and
  lazy initialization paths and all still pass.
