### PR TITLE
fix: exclude annotation types from mapper candidate components

### DIFF
--- a/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
+++ b/src/main/java/org/mybatis/spring/mapper/ClassPathMapperScanner.java
@@ -424,7 +424,9 @@ public class ClassPathMapperScanner extends ClassPathBeanDefinitionScanner {
 
   @Override
   protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
-    return beanDefinition.getMetadata().isInterface() && beanDefinition.getMetadata().isIndependent();
+    var metadata = beanDefinition.getMetadata();
+    // annotation types are interfaces too, but must never be treated as mapper candidates
+    return metadata.isInterface() && metadata.isIndependent() && !metadata.isAnnotation();
   }
 
   private boolean shouldUseClassConstructorArgument(Class<? extends MapperFactoryBean> mapperFactoryBeanClass) {

--- a/src/test/java/org/mybatis/spring/mapper/ClassPathMapperScannerAnnotationTest.java
+++ b/src/test/java/org/mybatis/spring/mapper/ClassPathMapperScannerAnnotationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mybatis.spring.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.scancandidate.ScanMapper;
+import org.springframework.context.support.GenericApplicationContext;
+
+class ClassPathMapperScannerAnnotationTest {
+
+  /**
+   * Annotation types are interfaces at the bytecode level, so they used to pass {@code isCandidateComponent} and were
+   * wrongly registered as mapper beans. They must be excluded while regular mapper interfaces in the same package are
+   * still scanned. See gh-1032.
+   */
+  @Test
+  void annotationTypeIsNotRegisteredAsMapper() {
+    try (var applicationContext = new GenericApplicationContext()) {
+      var scanner = new ClassPathMapperScanner(applicationContext, applicationContext.getEnvironment());
+      scanner.registerFilters();
+      scanner.scan(ScanMapper.class.getPackageName());
+
+      var beanDefinitionNames = List.of(applicationContext.getBeanDefinitionNames());
+
+      // the regular mapper interface is still picked up
+      assertThat(beanDefinitionNames).contains("scanMapper");
+      // the annotation type living in the same package must not be registered as a mapper
+      assertThat(applicationContext.containsBeanDefinition("scanMarkerAnnotation")).isFalse();
+    }
+  }
+}

--- a/src/test/java/org/mybatis/spring/scancandidate/ScanMapper.java
+++ b/src/test/java/org/mybatis/spring/scancandidate/ScanMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2010-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mybatis.spring.scancandidate;
+
+// a regular mapper interface that should be picked up by ClassPathMapperScanner
+public interface ScanMapper {
+  void method();
+}

--- a/src/test/java/org/mybatis/spring/scancandidate/ScanMarkerAnnotation.java
+++ b/src/test/java/org/mybatis/spring/scancandidate/ScanMarkerAnnotation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2010-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mybatis.spring.scancandidate;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+// an annotation type living in a scanned package; it is an interface at the bytecode level
+// but must NOT be registered as a mapper by ClassPathMapperScanner
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ScanMarkerAnnotation {
+}


### PR DESCRIPTION
Fixes #1032

## Problem
`ClassPathMapperScanner#isCandidateComponent` accepted any independent interface:

```java
return beanDefinition.getMetadata().isInterface() && beanDefinition.getMetadata().isIndependent();
```

Annotation types (`@interface`) are interfaces at the bytecode level and report `isInterface() == true` / `isIndependent() == true`. So an annotation declared inside a scanned base package passed this check and was wrongly registered as a `MapperFactoryBean`, as noted in #1032.

## Fix
Also require `!metadata.isAnnotation()`, so annotation types are excluded while regular mapper interfaces in the same package continue to be scanned.

## Test evidence
Added `ClassPathMapperScannerAnnotationTest`, which scans a package containing both a regular mapper interface and an annotation type, and asserts the mapper interface is registered while the annotation type is not. The test fails on `master` (the annotation type bean definition `scanMarkerAnnotation` is present) and passes with this change.

The supporting types live in a dedicated, otherwise-unscanned package (`org.mybatis.spring.scancandidate`) so existing scanner tests are unaffected.

`./mvnw test -Dlicense.skip=true` — `Tests run: 223, Failures: 0, Errors: 0, Skipped: 15` (BUILD SUCCESS).

Verification done: (1) no in-flight PR for the issue; (2) no claim comments on the thread; (3) code-focused change in `ClassPathMapperScanner.java`; (4) confirmed the pattern still exists on current `master`; (5) reproduced the bug with a failing test before applying the fix.