### PR TITLE
Improve mapper resource failure diagnostics

### DIFF
--- a/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
+++ b/src/main/java/org/mybatis/spring/SqlSessionFactoryBean.java
@@ -22,6 +22,7 @@ import static org.springframework.util.StringUtils.hasLength;
 import static org.springframework.util.StringUtils.tokenizeToStringArray;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Modifier;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -687,11 +688,21 @@ public class SqlSessionFactoryBean
             continue;
           }
           try {
-            var xmlMapperBuilder = new XMLMapperBuilder(mapperLocation.getInputStream(), targetConfiguration,
-                mapperLocation.toString(), targetConfiguration.getSqlFragments());
-            xmlMapperBuilder.parse();
-          } catch (Exception e) {
-            throw new IOException("Failed to parse mapping resource: '" + mapperLocation + "'", e);
+            final InputStream inputStream;
+            try {
+              inputStream = mapperLocation.getInputStream();
+            } catch (Exception e) {
+              throw new IOException("Failed to open mapping resource: '" + mapperLocation
+                  + "'. When using a resource pattern, resolve it with ResourcePatternResolver.getResources() before passing the results to setMapperLocations().",
+                  e);
+            }
+            try {
+              var xmlMapperBuilder = new XMLMapperBuilder(inputStream, targetConfiguration, mapperLocation.toString(),
+                  targetConfiguration.getSqlFragments());
+              xmlMapperBuilder.parse();
+            } catch (Exception e) {
+              throw new IOException("Failed to parse mapping resource: '" + mapperLocation + "'", e);
+            }
           } finally {
             ErrorContext.instance().reset();
           }

--- a/src/test/java/org/mybatis/spring/SqlSessionFactoryBeanTest.java
+++ b/src/test/java/org/mybatis/spring/SqlSessionFactoryBeanTest.java
@@ -20,8 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.mockrunner.mock.jdbc.MockDataSource;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -61,8 +63,10 @@ import org.mybatis.spring.type.DummyTypeAlias;
 import org.mybatis.spring.type.DummyTypeHandler;
 import org.mybatis.spring.type.SuperType;
 import org.mybatis.spring.type.TypeHandlerFactory;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 class SqlSessionFactoryBeanTest {
 
@@ -340,6 +344,41 @@ class SqlSessionFactoryBeanTest {
     factoryBean.setMapperLocations(new Resource[] { null });
 
     assertDefaultConfig(factoryBean.getObject());
+  }
+
+  @Test
+  void testSingleResourcePatternMapperLocationReportsResolutionHint() {
+    setupFactoryBean();
+    var resolver = new PathMatchingResourcePatternResolver();
+    var resource = resolver.getResource("classpath*:org/mybatis/spring/*Mapper.xml");
+    factoryBean.setMapperLocations(resource);
+
+    var exception = assertThrows(IOException.class, factoryBean::getObject);
+
+    assertThat(exception).hasMessageContaining("Failed to open mapping resource")
+        .hasMessageContaining("ResourcePatternResolver.getResources()");
+    assertThat(exception.getCause()).isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void testResourcePatternMapperLocations() throws Exception {
+    setupFactoryBean();
+    var resolver = new PathMatchingResourcePatternResolver();
+    factoryBean.setMapperLocations(resolver.getResources("classpath*:org/mybatis/spring/*Mapper.xml"));
+
+    assertThat(factoryBean.getObject()).isNotNull();
+  }
+
+  @Test
+  void testMalformedMapperLocationReportsParseFailure() {
+    setupFactoryBean();
+    var resource = new ByteArrayResource("not xml".getBytes(StandardCharsets.UTF_8));
+    factoryBean.setMapperLocations(resource);
+
+    var exception = assertThrows(IOException.class, factoryBean::getObject);
+
+    assertThat(exception).hasMessageContaining("Failed to parse mapping resource")
+        .hasMessageNotContaining("Failed to open mapping resource");
   }
 
   @Test

--- a/src/test/java/org/mybatis/spring/SqlSessionFactoryBeanTest.java
+++ b/src/test/java/org/mybatis/spring/SqlSessionFactoryBeanTest.java
@@ -20,8 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.mockrunner.mock.jdbc.MockDataSource;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -61,8 +63,10 @@ import org.mybatis.spring.type.DummyTypeAlias;
 import org.mybatis.spring.type.DummyTypeHandler;
 import org.mybatis.spring.type.SuperType;
 import org.mybatis.spring.type.TypeHandlerFactory;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 class SqlSessionFactoryBeanTest {
 
@@ -340,6 +344,32 @@ class SqlSessionFactoryBeanTest {
     factoryBean.setMapperLocations(new Resource[] { null });
 
     assertDefaultConfig(factoryBean.getObject());
+  }
+
+  @Test
+  void testSingleResourcePatternMapperLocationReportsResolutionHint() {
+    setupFactoryBean();
+    var resolver = new PathMatchingResourcePatternResolver();
+    var resource = resolver.getResource("classpath*:org/mybatis/spring/*Mapper.xml");
+    factoryBean.setMapperLocations(resource);
+
+    var exception = assertThrows(IOException.class, factoryBean::getObject);
+
+    assertThat(exception).hasMessageContaining("Failed to open mapping resource")
+        .hasMessageContaining("ResourcePatternResolver.getResources()");
+    assertThat(exception.getCause()).isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void testMalformedMapperLocationReportsParseFailure() {
+    setupFactoryBean();
+    var resource = new ByteArrayResource("not xml".getBytes(StandardCharsets.UTF_8));
+    factoryBean.setMapperLocations(resource);
+
+    var exception = assertThrows(IOException.class, factoryBean::getObject);
+
+    assertThat(exception).hasMessageContaining("Failed to parse mapping resource")
+        .hasMessageNotContaining("Failed to open mapping resource");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Report mapper resource opening failures separately from XML parsing failures.
- Suggest resolving wildcard locations with `ResourcePatternResolver.getResources()` before calling `setMapperLocations(...)`.
- Preserve the existing parse-failure diagnostic and `ErrorContext` reset behavior.

Closes #792

## Testing
- `./mvnw verify` (225 tests, 0 failures, 0 errors, 15 skipped)
- `git diff --check`